### PR TITLE
bug/5400-Dylan-removeBackA11yLabel

### DIFF
--- a/VAMobile/src/components/DescriptiveBackButton.tsx
+++ b/VAMobile/src/components/DescriptiveBackButton.tsx
@@ -1,9 +1,7 @@
 import { TouchableWithoutFeedback } from 'react-native'
 import { useFocusEffect } from '@react-navigation/native'
-import { useTranslation } from 'react-i18next'
 import React, { FC } from 'react'
 
-import { NAMESPACE } from 'constants/namespaces'
 import { useAccessibilityFocus, useTheme } from 'utils/hooks'
 import Box from './Box'
 import TextView from './TextView'
@@ -28,14 +26,13 @@ export type DescBackButtonProps = {
  */
 export const DescriptiveBackButton: FC<DescBackButtonProps> = ({ onPress, label, labelA11y, focusOnButton = true }) => {
   const theme = useTheme()
-  const { t } = useTranslation(NAMESPACE.COMMON)
 
   const [focusRef, setFocus] = useAccessibilityFocus<TouchableWithoutFeedback>()
 
   useFocusEffect(focusOnButton ? setFocus : () => {})
 
   return (
-    <TouchableWithoutFeedback ref={focusRef} onPress={onPress} accessibilityRole="button" accessibilityLabel={labelA11y ? labelA11y + t('back') : label + t('back')}>
+    <TouchableWithoutFeedback ref={focusRef} onPress={onPress} accessibilityRole="button" accessibilityLabel={labelA11y ? labelA11y : label}>
       <Box
         display="flex"
         flexDirection="row"


### PR DESCRIPTION
## Description of Change
Removed the "back" portion from descriptive back button component so back button now just reads as the displayed text

## Screenshots/Video
Before:



https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/810363fc-c231-41fc-8ccf-c501f7809778





After:



https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/440ada11-0bbd-4297-97e4-62b9cf074864








## Testing
Yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
[@Sparowhawk](https://github.com/Sparowhawk) Brea and I chatted about this today. We're still good with removing the "back" from the a11y label and we're also OK if that means that in some instances the back label is the same as the tab navigation label. Example: Benefits back button is same as Benefits tab label. We're OK with this because tapping both will take you to the same exact place: the Benefits category screen.
cc: [@brea11y](https://github.com/brea11y)

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
