### PR TITLE
Revert auth to use WebviewLogin on Android instead of Custom Tabs

### DIFF
--- a/VAMobile/android/Gemfile.lock
+++ b/VAMobile/android/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     CFPropertyList (3.0.6)
       rexml
-    addressable (2.8.4)
+    addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     artifactory (3.0.15)
     atomos (0.1.3)
@@ -105,7 +105,8 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-    fastlane-plugin-firebase_app_distribution (0.6.1)
+    fastlane-plugin-firebase_app_distribution (0.7.2)
+      google-apis-firebaseappdistribution_v1 (~> 0.3.0)
     fastlane-plugin-slack_bot (1.4.0)
     gh_inspector (1.1.3)
     google-apis-androidpublisher_v3 (0.46.0)
@@ -119,6 +120,8 @@ GEM
       retriable (>= 2.0, < 4.a)
       rexml
       webrick
+    google-apis-firebaseappdistribution_v1 (0.3.0)
+      google-apis-core (>= 0.11.0, < 2.a)
     google-apis-iamcredentials_v1 (0.17.0)
       google-apis-core (>= 0.11.0, < 2.a)
     google-apis-playcustomapp_v1 (0.13.0)
@@ -211,6 +214,7 @@ GEM
       xcpretty (~> 0.2, >= 0.0.7)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-19
   x86_64-darwin-20
   x86_64-darwin-21

--- a/VAMobile/src/App.tsx
+++ b/VAMobile/src/App.tsx
@@ -50,6 +50,7 @@ import OnboardingCarousel from './screens/OnboardingCarousel'
 import SnackBar from 'components/SnackBar'
 import SplashScreen from './screens/SplashScreen/SplashScreen'
 import VeteransCrisisLineScreen from './screens/HomeScreen/VeteransCrisisLineScreen/VeteransCrisisLineScreen'
+import WebviewLogin from './screens/auth/WebviewLogin'
 import WebviewScreen from './screens/WebviewScreen'
 import getEnv from 'utils/env'
 import store, { RootState } from 'store'
@@ -70,6 +71,13 @@ if (isIOS()) {
   KeyboardManager.setKeyboardDistanceFromTextField(45)
   KeyboardManager.setEnableAutoToolbar(false)
 }
+
+/**
+ * (https://github.com/react-native-webview/react-native-webview/issues/575)
+ * Potential fix for an Android specific crash issue related to react-navigation animations when
+ * transitioning to a webview
+ */
+const SHOW_LOGIN_VIEW_ANIMATION = isIOS()
 
 export type RootNavStackParamList = WebviewStackParams & {
   Home: undefined
@@ -258,6 +266,7 @@ export const AuthGuard: FC = () => {
         <Stack.Screen name="Login" component={LoginScreen} options={{ ...topPaddingAsHeaderStyles, title: t('login') }} />
         <Stack.Screen name="VeteransCrisisLine" component={VeteransCrisisLineScreen} options={LARGE_PANEL_OPTIONS} />
         <Stack.Screen name="Webview" component={WebviewScreen} />
+        <Stack.Screen name="WebviewLogin" component={WebviewLogin} options={{ headerShown: false, animationEnabled: SHOW_LOGIN_VIEW_ANIMATION }} />
         <Stack.Screen name="LoaGate" component={LoaGate} options={{ headerShown: false }} />
       </Stack.Navigator>
     )

--- a/VAMobile/src/screens/auth/LoaGate/LoaGate.tsx
+++ b/VAMobile/src/screens/auth/LoaGate/LoaGate.tsx
@@ -5,7 +5,6 @@ import { Box, ButtonTypesConstants, CollapsibleView, CrisisLineCta, FullScreenSu
 import { NAMESPACE } from 'constants/namespaces'
 import { useNavigation } from '@react-navigation/native'
 import { useRouteNavigation } from 'utils/hooks'
-import { useStartAuth } from 'utils/hooks/auth'
 import { useTheme } from 'utils/hooks'
 
 type LoaGateProps = Record<string, unknown>
@@ -13,9 +12,9 @@ type LoaGateProps = Record<string, unknown>
 const LoaGate: FC<LoaGateProps> = ({}) => {
   const theme = useTheme()
   const { t } = useTranslation(NAMESPACE.COMMON)
-  const startAuth = useStartAuth()
   const navigateTo = useRouteNavigation()
   const navigation = useNavigation()
+  const onConfirm = navigateTo('WebviewLogin')
   const onCrisisLine = navigateTo('VeteransCrisisLine')
 
   const bulletOne = {
@@ -65,7 +64,7 @@ const LoaGate: FC<LoaGateProps> = ({}) => {
         </CollapsibleView>
         <Box mt={theme.dimensions.textAndButtonLargeMargin}>
           <VAButton
-            onPress={startAuth}
+            onPress={onConfirm}
             label={t('continueToSignin')}
             buttonType={ButtonTypesConstants.buttonPrimary}
             a11yHint={t('continueToSignin.a11yHint')}

--- a/VAMobile/src/screens/auth/LoginScreen/LoginScreen.tsx
+++ b/VAMobile/src/screens/auth/LoginScreen/LoginScreen.tsx
@@ -1,10 +1,9 @@
 import { Pressable, StyleProp, ViewStyle } from 'react-native'
 import { useTranslation } from 'react-i18next'
-import React, { FC, useEffect, useState } from 'react'
+import React, { FC, useState } from 'react'
 
 import { AlertBox, Box, BoxProps, ButtonTypesConstants, CrisisLineCta, TextView, VAButton, VAIcon, VAScrollView } from 'components'
-import { AuthParamsLoadingStateTypeConstants } from 'store/api/types/auth'
-import { AuthState, loginStart, setPKCEParams } from 'store/slices/authSlice'
+import { AuthState, loginStart } from 'store/slices/authSlice'
 import { DemoState, updateDemoMode } from 'store/slices/demoSlice'
 import { NAMESPACE } from 'constants/namespaces'
 import { RootState } from 'store'
@@ -12,7 +11,6 @@ import { a11yLabelVA } from 'utils/a11yLabel'
 import { testIdProps } from 'utils/accessibility'
 import { useAppDispatch, useRouteNavigation, useTheme } from 'utils/hooks'
 import { useSelector } from 'react-redux'
-import { useStartAuth } from 'utils/hooks/auth'
 import AppVersionAndBuild from 'components/AppVersionAndBuild'
 import DemoAlert from './DemoAlert'
 import getEnv from 'utils/env'
@@ -20,21 +18,11 @@ import getEnv from 'utils/env'
 const LoginScreen: FC = () => {
   const { t } = useTranslation([NAMESPACE.COMMON, NAMESPACE.HOME])
   const { firstTimeLogin } = useSelector<RootState, AuthState>((state) => state.auth)
-  const { authParamsLoadingState } = useSelector<RootState, AuthState>((state) => state.auth)
-
-  const dispatch = useAppDispatch()
   const navigateTo = useRouteNavigation()
-  const startAuth = useStartAuth()
   const theme = useTheme()
   const [demoPromptVisible, setDemoPromptVisible] = useState(false)
   const TAPS_FOR_DEMO = 20
   let demoTaps = 0
-
-  useEffect(() => {
-    if (authParamsLoadingState === AuthParamsLoadingStateTypeConstants.INIT) {
-      dispatch(setPKCEParams())
-    }
-  }, [authParamsLoadingState, dispatch])
 
   const { WEBVIEW_URL_FACILITY_LOCATOR } = getEnv()
 
@@ -63,6 +51,7 @@ const LoginScreen: FC = () => {
     testID: 'findVALocationTestID',
   }
 
+  const dispatch = useAppDispatch()
   const handleUpdateDemoMode = () => {
     dispatch(updateDemoMode(true))
   }
@@ -81,7 +70,7 @@ const LoginScreen: FC = () => {
       }
     : firstTimeLogin
     ? navigateTo('LoaGate')
-    : startAuth
+    : navigateTo('WebviewLogin')
 
   return (
     <VAScrollView {...testIdProps('Login-page', true)} contentContainerStyle={mainViewStyle}>

--- a/VAMobile/src/screens/auth/WebviewLogin/WebviewLogin.test.tsx
+++ b/VAMobile/src/screens/auth/WebviewLogin/WebviewLogin.test.tsx
@@ -1,7 +1,7 @@
 import 'react-native'
 import React from 'react'
 // Note: test renderer must be required after react-native.
-import { render, context, mockNavProps, waitFor } from 'testUtils'
+import { render, context, mockNavProps } from 'testUtils'
 
 import WebviewLogin from './WebviewLogin'
 import { initialAuthState } from 'store/slices'

--- a/VAMobile/src/screens/auth/WebviewLogin/WebviewLogin.test.tsx
+++ b/VAMobile/src/screens/auth/WebviewLogin/WebviewLogin.test.tsx
@@ -1,0 +1,35 @@
+import 'react-native'
+import React from 'react'
+// Note: test renderer must be required after react-native.
+import { render, context, mockNavProps, waitFor } from 'testUtils'
+
+import WebviewLogin from './WebviewLogin'
+import { initialAuthState } from 'store/slices'
+
+jest.mock('utils/analytics', () => ({
+  logAnalyticsEvent: jest.fn(),
+  logNonFatalErrorToFirebase: jest.fn(),
+}))
+
+context('WebviewLogin', () => {
+  let component: any
+
+  beforeEach(async () => {
+    const mockProps = mockNavProps(
+      {},
+      {
+        navigate: jest.fn(),
+      },
+    )
+
+    component = render(<WebviewLogin {...mockProps} />, {
+      preloadedState: {
+        auth: { ...initialAuthState },
+      },
+    })
+  })
+
+  it('initializes correctly', async () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/VAMobile/src/screens/auth/WebviewLogin/WebviewLogin.tsx
+++ b/VAMobile/src/screens/auth/WebviewLogin/WebviewLogin.tsx
@@ -15,7 +15,7 @@ import { featureEnabled } from 'utils/remoteConfig'
 import { isErrorObject } from 'utils/common'
 import { isIOS } from 'utils/platform'
 import { logNonFatalErrorToFirebase } from 'utils/analytics'
-import { startIosAuthSession } from 'utils/rnAuthSesson'
+import { startAuthSession } from 'utils/rnAuthSesson'
 import { testIdProps } from 'utils/accessibility'
 import { useAppDispatch } from 'utils/hooks'
 import getEnv from 'utils/env'
@@ -61,7 +61,7 @@ const WebviewLogin: FC<WebviewLoginProps> = ({ navigation }) => {
   useEffect(() => {
     const iosAuth = async () => {
       try {
-        const callbackUrl = await startIosAuthSession(codeChallenge || '', authorizeStateParam || '')
+        const callbackUrl = await startAuthSession(codeChallenge || '', authorizeStateParam || '')
         dispatch(handleTokenCallbackUrl(callbackUrl))
       } catch (e) {
         // code "000" comes back from the RCT bridge if the user cancelled the log in, all other errors are code '001'

--- a/VAMobile/src/screens/auth/WebviewLogin/WebviewLogin.tsx
+++ b/VAMobile/src/screens/auth/WebviewLogin/WebviewLogin.tsx
@@ -1,0 +1,122 @@
+import { StyleProp, ViewStyle } from 'react-native'
+import { WebView } from 'react-native-webview'
+import { useSelector } from 'react-redux'
+import { useTranslation } from 'react-i18next'
+import React, { FC, ReactElement, useEffect } from 'react'
+
+import { AuthParamsLoadingStateTypeConstants } from 'store/api/types/auth'
+import { AuthState, cancelWebLogin, handleTokenCallbackUrl, sendLoginFailedAnalytics, sendLoginStartAnalytics, setPKCEParams } from 'store/slices/authSlice'
+import { Box, HeaderBanner, HeaderBannerProps, LoadingComponent } from 'components'
+import { NAMESPACE } from 'constants/namespaces'
+import { RootState } from 'store'
+import { StackScreenProps } from '@react-navigation/stack/lib/typescript/src/types'
+import { WebviewStackParams } from '../../WebviewScreen/WebviewScreen'
+import { featureEnabled } from 'utils/remoteConfig'
+import { isErrorObject } from 'utils/common'
+import { isIOS } from 'utils/platform'
+import { logNonFatalErrorToFirebase } from 'utils/analytics'
+import { startIosAuthSession } from 'utils/rnAuthSesson'
+import { testIdProps } from 'utils/accessibility'
+import { useAppDispatch } from 'utils/hooks'
+import getEnv from 'utils/env'
+import qs from 'querystringify'
+
+type WebviewLoginProps = StackScreenProps<WebviewStackParams, 'Webview'>
+const WebviewLogin: FC<WebviewLoginProps> = ({ navigation }) => {
+  const dispatch = useAppDispatch()
+  const { AUTH_IAM_CLIENT_ID, AUTH_IAM_REDIRECT_URL, AUTH_IAM_SCOPES, AUTH_IAM_ENDPOINT, AUTH_SIS_ENDPOINT } = getEnv()
+  const { codeChallenge, authorizeStateParam, authParamsLoadingState } = useSelector<RootState, AuthState>((state) => state.auth)
+  const { t } = useTranslation(NAMESPACE.COMMON)
+
+  const SIS_ENABLED = featureEnabled('SIS')
+
+  const params = qs.stringify({
+    code_challenge: codeChallenge,
+    code_challenge_method: 'S256',
+    ...(SIS_ENABLED
+      ? {
+          application: 'vamobile',
+          oauth: 'true',
+        }
+      : {
+          client_id: AUTH_IAM_CLIENT_ID,
+          redirect_uri: AUTH_IAM_REDIRECT_URL,
+          scope: AUTH_IAM_SCOPES,
+          response_type: 'code',
+          response_mode: 'query',
+          state: authorizeStateParam,
+        }),
+  })
+  const webLoginUrl = `${SIS_ENABLED ? AUTH_SIS_ENDPOINT : AUTH_IAM_ENDPOINT}?${params}`
+  const webviewStyle: StyleProp<ViewStyle> = {
+    flex: 1,
+  }
+
+  useEffect(() => {
+    if (authParamsLoadingState === AuthParamsLoadingStateTypeConstants.INIT) {
+      dispatch(setPKCEParams())
+    }
+  }, [authParamsLoadingState, dispatch])
+
+  useEffect(() => {
+    const iosAuth = async () => {
+      try {
+        const callbackUrl = await startIosAuthSession(codeChallenge || '', authorizeStateParam || '')
+        dispatch(handleTokenCallbackUrl(callbackUrl))
+      } catch (e) {
+        // code "000" comes back from the RCT bridge if the user cancelled the log in, all other errors are code '001'
+        if (isErrorObject(e)) {
+          if (e.code === '000') {
+            dispatch(cancelWebLogin())
+            navigation.goBack()
+          } else {
+            logNonFatalErrorToFirebase(e, 'iOS Login Error')
+            dispatch(sendLoginFailedAnalytics(e))
+          }
+        }
+      }
+    }
+    dispatch(sendLoginStartAnalytics())
+    if (authParamsLoadingState === AuthParamsLoadingStateTypeConstants.READY && isIOS()) {
+      iosAuth()
+    }
+  }, [authParamsLoadingState, codeChallenge, authorizeStateParam, dispatch, navigation])
+
+  const loadingSpinner: ReactElement = (
+    <Box display="flex" height="100%" width="100%">
+      <LoadingComponent text={t('webview.preLogin.message')} />
+    </Box>
+  )
+
+  // if the OS is iOS, we return the empty screen because the OS will slide the ASWebAuthenticationSession view over the screen
+  if (isIOS()) {
+    return <></>
+  } else if (authParamsLoadingState !== AuthParamsLoadingStateTypeConstants.READY) {
+    return <LoadingComponent text={t('webview.preLogin.message')} />
+  } else {
+    const headerProps: HeaderBannerProps = { leftButton: { text: t('cancel'), onPress: navigation.goBack }, title: { type: 'Static', title: t('signin') } }
+    return (
+      <>
+        <HeaderBanner {...headerProps} />
+        <Box style={webviewStyle}>
+          <WebView
+            source={{ uri: webLoginUrl }}
+            incognito={true}
+            startInLoadingState
+            onError={(e) => {
+              const err = new Error(e.nativeEvent.description)
+              err.stack = JSON.stringify(e.nativeEvent)
+              err.name = e.nativeEvent.title
+              logNonFatalErrorToFirebase(err, 'Android Login Webview Error')
+              dispatch(sendLoginFailedAnalytics(err))
+            }}
+            renderLoading={(): ReactElement => loadingSpinner}
+            {...testIdProps('Sign-in: Webview-login', true)}
+          />
+        </Box>
+      </>
+    )
+  }
+}
+
+export default WebviewLogin

--- a/VAMobile/src/screens/auth/WebviewLogin/index.ts
+++ b/VAMobile/src/screens/auth/WebviewLogin/index.ts
@@ -1,0 +1,1 @@
+export { default } from './WebviewLogin'

--- a/VAMobile/src/utils/rnAuthSesson.tsx
+++ b/VAMobile/src/utils/rnAuthSesson.tsx
@@ -9,7 +9,7 @@ const { AUTH_IAM_ENDPOINT, AUTH_SIS_ENDPOINT, AUTH_IAM_CLIENT_ID, AUTH_IAM_REDIR
  * This function fires the native iOS log in system for OAuth and returns a promise with the callback url string to continue log in
  * @returns Promise<string> returns a promise with the callback url for log in with the OAuth exchange code query param
  */
-export const startIosAuthSession = async (codeChallenge: string, stateParam: string): Promise<string> => {
+export const startAuthSession = async (codeChallenge: string, stateParam: string): Promise<string> => {
   const SISEnabled = featureEnabled('SIS')
   return await RnAuthSession.beginAuthSession(
     SISEnabled ? AUTH_SIS_ENDPOINT : AUTH_IAM_ENDPOINT,

--- a/VAMobile/src/utils/rnAuthSesson.tsx
+++ b/VAMobile/src/utils/rnAuthSesson.tsx
@@ -1,39 +1,23 @@
 import { NativeModules } from 'react-native'
 import { featureEnabled } from 'utils/remoteConfig'
-import { isIOS } from 'utils/platform'
 import getEnv from 'utils/env'
 
 const RnAuthSession = NativeModules.RNAuthSession
-const CustomTabs = NativeModules.CustomTabsIntentModule
 const { AUTH_IAM_ENDPOINT, AUTH_SIS_ENDPOINT, AUTH_IAM_CLIENT_ID, AUTH_IAM_REDIRECT_URL, AUTH_IAM_SCOPES } = getEnv()
 
 /**
- * This function fires the native iOS ASWebAuthenticationSession and Custom Tabs
- * in the case of Android
- * @returns Promise<string> For iOS, returns a promise with the callback
- * url for log in with the OAuth exchange code query param.
+ * This function fires the native iOS log in system for OAuth and returns a promise with the callback url string to continue log in
+ * @returns Promise<string> returns a promise with the callback url for log in with the OAuth exchange code query param
  */
-export const startAuthSession = async (codeChallenge: string, stateParam: string): Promise<string> => {
+export const startIosAuthSession = async (codeChallenge: string, stateParam: string): Promise<string> => {
   const SISEnabled = featureEnabled('SIS')
-  if (isIOS()) {
-    return await RnAuthSession.beginAuthSession(
-      SISEnabled ? AUTH_SIS_ENDPOINT : AUTH_IAM_ENDPOINT,
-      AUTH_IAM_CLIENT_ID,
-      AUTH_IAM_REDIRECT_URL,
-      AUTH_IAM_SCOPES,
-      codeChallenge,
-      stateParam,
-      SISEnabled,
-    )
-  } else {
-    return await CustomTabs.beginAuthSession(
-      SISEnabled ? AUTH_SIS_ENDPOINT : AUTH_IAM_ENDPOINT,
-      AUTH_IAM_CLIENT_ID,
-      AUTH_IAM_REDIRECT_URL,
-      AUTH_IAM_SCOPES,
-      codeChallenge,
-      stateParam,
-      SISEnabled,
-    )
-  }
+  return await RnAuthSession.beginAuthSession(
+    SISEnabled ? AUTH_SIS_ENDPOINT : AUTH_IAM_ENDPOINT,
+    AUTH_IAM_CLIENT_ID,
+    AUTH_IAM_REDIRECT_URL,
+    AUTH_IAM_SCOPES,
+    codeChallenge,
+    stateParam,
+    SISEnabled,
+  )
 }


### PR DESCRIPTION
<!-- NOTE: Please include the related issue number in the PR title, otherwise the changes won't be merged 
into the `staging` branch upon ticket completion. E.g. '[Issue type]/[Issue #]-[Your name]-[Summary of issue]',
where Issue type = bug, feature, spike, CU (code upkeep), etc. -->

## Description of Change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, 
need to know about this PR in order to understand why this PR was created? This could include dependencies 
introduced, changes in behavior, pointers to more detailed documentation. The description should be more 
than a link to an issue.  -->
Reverting Custom Tab work done in https://github.com/department-of-veterans-affairs/va-mobile-app/pull/6093 due to an increase of auth errors reported by the SIS team. 

Users with older versions of Chrome are not being redirected to the app after the log in process. They get stuck on a white screen because [older versions of Chrome do not allow deep links to be auto-launched with JavaScript](https://bugs.chromium.org/p/chromium/issues/detail?id=738724). We'll need to work with the SIS team to figure out a solution, but are reverting back to the old in-app WebView in the meantime.

## Screenshots/Video
<!-- Add screenshots or video as needed. Before/after if changes are to be compared by reviewers.
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Toggle: <details><summary></summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>
-->
<details><summary>Android Before</summary><img src="" width="49%" />&nbsp;&nbsp;
<img src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/786704/3604a789-66d8-4c8c-9e28-4784ed1b0032" width="320" />

https://github.com/department-of-veterans-affairs/va-mobile-app/assets/786704/fea625ab-abd4-443c-bcae-1afd7862c91d

</details>


<details><summary>Android After</summary><img src="" width="49%" />&nbsp;&nbsp;
<img src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/786704/773b6730-14b7-48be-a1ca-aea8f5593f92" width="320" />

https://github.com/department-of-veterans-affairs/va-mobile-app/assets/786704/647693ce-6bf7-443d-b9b1-4e26577c24ad



</details>


## Testing
<!-- What testing was done to verify the changes (local/unit)? What testing remains? Note edge cases, or special
situations that could not be tested during development. -->

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
<!-- What should reviewers look for? Copy/paste Acceptance Criteria from ticket -->
- [ ] iOS auth flow should work normally
- [ ] Android auth flow should be using old webview instead of Custom Tabs and user should be able to log in successfully (header is the main distinction)

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [ ] PR is connected to issue(s)
- [ ] Tests are included to cover this change (when possible)
- [ ] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [ ] No secrets or API keys are checked in
- [ ] All imports are absolute (no relative imports)
- [ ] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
