### PR TITLE
feature/6387-Dylan-ChangeConfirmedApptsToTagGreen

### DIFF
--- a/VAMobile/src/utils/appointments.tsx
+++ b/VAMobile/src/utils/appointments.tsx
@@ -208,7 +208,7 @@ export const getTextLinesForAppointmentListItem = (appointment: AppointmentData,
   if (attributes.status === AppointmentStatusConstants.CANCELLED) {
     textLines.push({ text: t('appointments.canceled'), textTag: { labelType: LabelTagTypeConstants.tagInactive }, mb: condensedMarginBetween })
   } else if (attributes.status === AppointmentStatusConstants.BOOKED) {
-    textLines.push({ text: t('appointments.confirmed'), textTag: { labelType: LabelTagTypeConstants.tagBlue }, mb: condensedMarginBetween })
+    textLines.push({ text: t('appointments.confirmed'), textTag: { labelType: LabelTagTypeConstants.tagGreen }, mb: condensedMarginBetween })
   } else if (isPendingAppointment) {
     textLines.push({ text: t('appointments.pending'), textTag: { labelType: LabelTagTypeConstants.tagYellow }, mb: condensedMarginBetween })
   }


### PR DESCRIPTION
## Description of Change
Changed Appointment Tag from blue to green for confirmed appointments

## Screenshots/Video

Toggle: <details><summary>Before/after:</summary><img src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/a95b35ef-de51-4eb8-9878-2b436856dee6" width="49%" />&nbsp;&nbsp;<img src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/8f50374d-65ee-4882-b28b-dd072e538000" width="49%" /></details>


## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
Acceptance criteria:
 Change Confirmed tags to tagGreen (success)
 Ensure all Confirmed tags are tagGreen (success)

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
