### PR TITLE
bug/5785-Dylan-NoClosedClaimsAppealsCopy

### DIFF
--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimsAndAppealsListView/ClaimsAndAppealsListView.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimsAndAppealsListView/ClaimsAndAppealsListView.tsx
@@ -84,7 +84,7 @@ const ClaimsAndAppealsListView: FC<ClaimsAndAppealsListProps> = ({ claimType }) 
   }
 
   if (claimsAndAppeals.length === 0) {
-    return <NoClaimsAndAppeals />
+    return <NoClaimsAndAppeals claimType={claimType} />
   }
 
   const yourClaimsAndAppealsHeader = t('claims.youClaimsAndAppeals', { claimType: claimType.toLowerCase() })

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/NoClaimsAndAppeals/NoClaimsAndAppeals.test.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/NoClaimsAndAppeals/NoClaimsAndAppeals.test.tsx
@@ -8,6 +8,7 @@ import { ReactTestInstance } from 'react-test-renderer'
 import NoClaimsAndAppeals from './NoClaimsAndAppeals'
 import { InitialState } from 'store/slices'
 import { TextView } from 'components'
+import { ClaimTypeConstants } from '../ClaimsAndAppealsListView/ClaimsAndAppealsListView'
 
 context('NoClaimsAndAppeals', () => {
   let component: RenderAPI
@@ -15,7 +16,7 @@ context('NoClaimsAndAppeals', () => {
 
   const initializeTestInstance = async (claimsServiceError = false, appealsServiceError = false) => {
     await waitFor(() => {
-      component = render(<NoClaimsAndAppeals />, {
+      component = render(<NoClaimsAndAppeals claimType={ClaimTypeConstants.ACTIVE} />, {
         preloadedState: {
           ...InitialState,
           claimsAndAppeals: {

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/NoClaimsAndAppeals/NoClaimsAndAppeals.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/NoClaimsAndAppeals/NoClaimsAndAppeals.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next'
 import React, { FC } from 'react'
 
 import { Box, TextView } from 'components'
+import { ClaimType, ClaimTypeConstants } from '../ClaimsAndAppealsListView/ClaimsAndAppealsListView'
 import { ClaimsAndAppealsState } from 'store/slices'
 import { NAMESPACE } from 'constants/namespaces'
 import { RootState } from 'store'
@@ -9,7 +10,11 @@ import { testIdProps } from 'utils/accessibility'
 import { useSelector } from 'react-redux'
 import { useTheme } from 'utils/hooks'
 
-const NoClaimsAndAppeals: FC = () => {
+type NoClaimsAndAppealsProps = {
+  claimType: ClaimType
+}
+
+const NoClaimsAndAppeals: FC<NoClaimsAndAppealsProps> = ({ claimType }) => {
   const { t } = useTranslation(NAMESPACE.COMMON)
   const theme = useTheme()
   const { claimsServiceError, appealsServiceError } = useSelector<RootState, ClaimsAndAppealsState>((state) => state.claimsAndAppeals)
@@ -23,6 +28,9 @@ const NoClaimsAndAppeals: FC = () => {
   } else if (appealsServiceError) {
     header = t('noClaims.youDontHaveAnyClaims')
     text = t('noClaims.appOnlyShowsCompletedClaims')
+  } else if (claimType === ClaimTypeConstants.CLOSED) {
+    header = t('noClaims.youDontHaveAnyClosedClaimsOrAppeals')
+    text = ''
   }
 
   return (

--- a/VAMobile/src/translations/en/common.json
+++ b/VAMobile/src/translations/en/common.json
@@ -628,6 +628,7 @@
   "noClaims.youDontHaveAnyAppeals": "You don't have any appeals",
   "noClaims.youDontHaveAnyClaims": "You don't have any submitted claims",
   "noClaims.youDontHaveAnyClaimsOrAppeals": "You don't have any submitted claims or appeals",
+  "noClaims.youDontHaveAnyClosedClaimsOrAppeals": "You don't have any closed claims or appeals",
   "claims.title": "Claims",
   "claimsHistory.title": "Claims history",
   "claimLetters.title": "Claim letters",


### PR DESCRIPTION
## Description of Change
Changed the copy when user is looking at closed claims in the claims history screen to accurately state they only have no closed claims or appeals.

## Screenshots/Video
Toggle: <details><summary>Before/after:</summary><img src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/d4c5c37c-18f2-4f35-852c-6d2ed333658c" width="49%" />&nbsp;&nbsp;<img src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/844e700e-a648-4dca-9b45-182054b56b82" width="49%" /></details>

## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
 Header copy: You don't have any closed claims or appeals
 No body copy needed

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
