### PR TITLE
bug/5988-Dylan-SnackbarDismissOnNavFromLettersLandingPage

### DIFF
--- a/VAMobile/src/constants/common.ts
+++ b/VAMobile/src/constants/common.ts
@@ -54,6 +54,7 @@ const screensToCloseSnackbarOnNavigation = [
   'UploadFile',
   'UploadOrAddPhotos',
   'ViewMessageScreen',
+  'LettersOverview',
 ]
 
 export const CloseSnackbarOnNavigation = (screenName: string | undefined) => {


### PR DESCRIPTION
## Description of Change
Added LettersOverview page to list of screens we dismiss snackbar on navigation

## Screenshots/Video
Before:

https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/2517a1d7-e88d-4e12-a950-afbfb648e3eb


After:

https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/ff8ff7e8-82b1-4551-90fe-396d7972f426



## Testing
Yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
Snackbar should dismiss on navigating away

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
