### PR TITLE
Updated build tools version to 33

### DIFF
--- a/VAMobile/android/build.gradle
+++ b/VAMobile/android/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     ext {
-        buildToolsVersion = "31.0.0"
+        buildToolsVersion = "33.0.0"
         minSdkVersion = 26
         compileSdkVersion = 33
         targetSdkVersion = 33


### PR DESCRIPTION
We got a warning that our target API level in Android needed to be updated to 33: https://play.google.com/console/u/0/developers/7507611851470273082/app/4974294731909201030/policy-center/issues/4988276614632641488/details

The deadline for this is Aug 30, 2023 or we won't be able to release to the play store.

**Violation**
App must target Android 13 (API level 33) or higher

> To provide users with a safe and secure experience, Google Play requires all apps to meet target API level requirements.
From Aug 30, 2023, if your target API level is not within 1 year of the latest Android release, you won't be able to update your app.

Research from here: https://onkarjanwa.com/how-to-update-android-target-api-level-in-react-native/

Verified working in emulator

<img width="512" alt="Screenshot 2023-08-21 at 11 14 04 AM" src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/459581/14c17840-cccd-42e3-8529-7c2e42ebfdd0">
