### PR TITLE
docs - BE - remove staging and prod updates in Devops.md

### DIFF
--- a/VAMobile/documentation/docs/Engineering/BackEnd/Architecture/Devops.md
+++ b/VAMobile/documentation/docs/Engineering/BackEnd/Architecture/Devops.md
@@ -32,16 +32,7 @@ mobile_lighthouse_letters:
 ```
 3. Repeat these steps for the production files in `apps/vets-api/prod`. Dev env is not used by mobile and does not need to be added there.
 ## Devops Repo
-Once the the Manifests additions have been merged, add the variables to [devops repo](https://github.com/department-of-veterans-affairs/devops) in the following locations:
-1. `ansible/deployment/config/vets-api/staging-settings.local.yml.j2`: Referencing AWS path.
-```
-mobile_lighthouse:
-  client_id: "{{ lookup('aws_ssm_custom', '/dsva-vagov/vets-api/staging/mobile_lighthouse/client_id') }}"
-  rsa_key: "{{ lookup('aws_ssm_custom', '/dsva-vagov/vets-api/staging/mobile_lighthouse/rsa_key') }}"
-
-```
-2. `ansible/deployment/config/vets-api/prod-settings.local.yml.j2`: Same format as staging
-3. `ansible/roles/review-instance-configure/vars/settings.local.yml`: Used for populating values in review instances. 
+If you'd like to use these values in review instances, after updating Manifests repo, add the variables to [devops repo](https://github.com/department-of-veterans-affairs/devops) in `ansible/roles/review-instance-configure/vars/settings.local.yml` 
 
 ## Adding Local Settings
 Add a new section to `config/settings.yml` in the vets-api. See mobile entry `lighthouse_health_immunization` as reference.


### PR DESCRIPTION
## Description of Change
We no longer need to add credentials to devops, only manifests. see convo: https://dsva.slack.com/archives/CBU0KDSB1/p1693235319494289?thread_ts=1692998447.156059&cid=CBU0KDSB1



## Screenshots/Video
<!-- Add screenshots or video as needed. Before/after if changes are to be compared by reviewers.
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Toggle: <details><summary></summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>
-->

## Testing
<!-- What testing was done to verify the changes (local/unit)? What testing remains? Note edge cases, or special
situations that could not be tested during development. -->

- [ ] Tested on iOS <!-- simulator is fine -->
- [ ] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
<!-- What should reviewers look for? Copy/paste Acceptance Criteria from ticket -->

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [ ] PR is connected to issue(s)
- [ ] Tests are included to cover this change (when possible)
- [ ] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [ ] No secrets or API keys are checked in
- [ ] All imports are absolute (no relative imports)
- [ ] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
