### PR TITLE
bug/5068-Dylan-BSSVLettersLoadingFix

### DIFF
--- a/VAMobile/src/screens/BenefitsScreen/Letters/BenefitSummaryServiceVerification/BenefitSummaryServiceVerification.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/Letters/BenefitSummaryServiceVerification/BenefitSummaryServiceVerification.tsx
@@ -41,7 +41,9 @@ const BenefitSummaryServiceVerification: FC<BenefitSummaryServiceVerificationPro
   const { t } = useTranslation(NAMESPACE.COMMON)
   const theme = useTheme()
   const dispatch = useAppDispatch()
-  const { downloading, letterBeneficiaryData, mostRecentServices, letterDownloadError } = useSelector<RootState, LettersState>((state) => state.letters)
+  const { downloading, letterBeneficiaryData, mostRecentServices, letterDownloadError, loadingLetterBeneficiaryData } = useSelector<RootState, LettersState>(
+    (state) => state.letters,
+  )
 
   const [includeMilitaryServiceInfoToggle, setIncludeMilitaryServiceInfoToggle] = useState(true)
   const [monthlyAwardToggle, setMonthlyAwardToggle] = useState(true)
@@ -214,7 +216,7 @@ const BenefitSummaryServiceVerification: FC<BenefitSummaryServiceVerificationPro
     )
   }
 
-  if (downloading || !letterBeneficiaryData) {
+  if (loadingLetterBeneficiaryData || downloading || !letterBeneficiaryData) {
     return (
       <FeatureLandingTemplate backLabel={t('letters.overview.viewLetters')} backLabelOnPress={navigation.goBack} title={t('letters.details.title')}>
         <LoadingComponent text={t(downloading ? 'letters.loading' : 'letters.benefitService.loading')} />

--- a/VAMobile/src/store/slices/lettersSlice.test.ts
+++ b/VAMobile/src/store/slices/lettersSlice.test.ts
@@ -207,9 +207,6 @@ context('letters', () => {
       await store.dispatch(getLetterBeneficiaryData())
       const actions = store.getActions()
 
-      const startAction = _.find(actions, { type: ActionTypes.LETTER_START_GET_BENEFICIARY_DATA })
-      expect(startAction).toBeTruthy()
-
       const endAction = _.find(actions, { type: ActionTypes.LETTER_FINISH_GET_BENEFICIARY_DATA })
       expect(endAction).toBeTruthy()
       expect(endAction?.state.letters.loading).toBe(false)

--- a/VAMobile/src/store/slices/lettersSlice.test.ts
+++ b/VAMobile/src/store/slices/lettersSlice.test.ts
@@ -207,6 +207,9 @@ context('letters', () => {
       await store.dispatch(getLetterBeneficiaryData())
       const actions = store.getActions()
 
+      const startAction = _.find(actions, { type: ActionTypes.LETTER_START_GET_BENEFICIARY_DATA })
+      expect(startAction).toBeTruthy()
+
       const endAction = _.find(actions, { type: ActionTypes.LETTER_FINISH_GET_BENEFICIARY_DATA })
       expect(endAction).toBeTruthy()
       expect(endAction?.state.letters.loading).toBe(false)

--- a/VAMobile/src/store/slices/lettersSlice.ts
+++ b/VAMobile/src/store/slices/lettersSlice.ts
@@ -79,10 +79,10 @@ export const getLetterBeneficiaryData =
   async (dispatch) => {
     dispatch(dispatchClearErrors(screenID))
     dispatch(dispatchSetTryAgainFunction(() => dispatch(getLetterBeneficiaryData(screenID))))
-    dispatch(dispatchStartGetLetterBeneficiaryData())
 
     try {
       const letterBeneficiaryData = await api.get<api.LetterBeneficiaryDataPayload>('/v0/letters/beneficiary')
+      dispatch(dispatchStartGetLetterBeneficiaryData())
       dispatch(dispatchFinishGetLetterBeneficiaryData({ letterBeneficiaryData: letterBeneficiaryData?.data.attributes }))
     } catch (error) {
       if (isErrorObject(error)) {

--- a/VAMobile/src/store/slices/lettersSlice.ts
+++ b/VAMobile/src/store/slices/lettersSlice.ts
@@ -33,6 +33,7 @@ const lettersNonFatalErrorString = 'Letters Service Error'
 
 export type LettersState = {
   loading: boolean
+  loadingLetterBeneficiaryData: boolean
   error?: Error
   letters: LettersList
   letterBeneficiaryData?: LetterBeneficiaryData
@@ -43,6 +44,7 @@ export type LettersState = {
 
 export const initialLettersState: LettersState = {
   loading: false,
+  loadingLetterBeneficiaryData: false,
   letters: [] as LettersList,
   mostRecentServices: [],
   downloading: false,
@@ -79,10 +81,10 @@ export const getLetterBeneficiaryData =
   async (dispatch) => {
     dispatch(dispatchClearErrors(screenID))
     dispatch(dispatchSetTryAgainFunction(() => dispatch(getLetterBeneficiaryData(screenID))))
+    dispatch(dispatchStartGetLetterBeneficiaryData())
 
     try {
       const letterBeneficiaryData = await api.get<api.LetterBeneficiaryDataPayload>('/v0/letters/beneficiary')
-      dispatch(dispatchStartGetLetterBeneficiaryData())
       dispatch(dispatchFinishGetLetterBeneficiaryData({ letterBeneficiaryData: letterBeneficiaryData?.data.attributes }))
     } catch (error) {
       if (isErrorObject(error)) {
@@ -165,7 +167,7 @@ const lettersSlice = createSlice({
     },
 
     dispatchStartGetLetterBeneficiaryData: (state) => {
-      state.loading = true
+      state.loadingLetterBeneficiaryData = true
     },
 
     dispatchFinishGetLetterBeneficiaryData: (state, action: PayloadAction<{ letterBeneficiaryData?: LetterBeneficiaryData; error?: Error }>) => {
@@ -187,7 +189,7 @@ const lettersSlice = createSlice({
       state.letterBeneficiaryData = letterBeneficiaryData
       state.mostRecentServices = mostRecentServices
       state.error = error
-      state.loading = false
+      state.loadingLetterBeneficiaryData = false
     },
 
     dispatchStartDownloadLetter: (state) => {


### PR DESCRIPTION
## Description of Change
Updated the loading boolean for BSSV to be different from the letters list screen. This was what was causing both loadings to occur after each other.

## Screenshots/Video

https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/b8e17f05-1b72-426f-84fe-8a83b61193da



## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
It'd be nicer to only display the desired loading screen, and not the letters list one first.

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
