### PR TITLE
bug/6489-Dylan-RemoveTrashAsMovableFolder

### DIFF
--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/ViewMessage/ViewMessageScreen.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/ViewMessage/ViewMessageScreen.tsx
@@ -8,7 +8,7 @@ import { BackButtonLabelConstants } from 'constants/backButtonLabels'
 import { DateTime } from 'luxon'
 import { DemoState } from 'store/slices/demoSlice'
 import { Events } from 'constants/analytics'
-import { FolderNameTypeConstants, REPLY_WINDOW_IN_DAYS, TRASH_FOLDER_NAME } from 'constants/secureMessaging'
+import { FolderNameTypeConstants, REPLY_WINDOW_IN_DAYS } from 'constants/secureMessaging'
 import { GenerateFolderMessage } from 'translations/en/functions'
 import { HealthStackParamList } from 'screens/HealthScreen/HealthStackScreens'
 import { NAMESPACE } from 'constants/namespaces'
@@ -91,12 +91,11 @@ const ViewMessageScreen: FC<ViewMessageScreenProps> = ({ route, navigation }) =>
   }, [dispatch, folders])
 
   const getFolders = (): PickerItem[] => {
-    let indexOfDeleted: number | undefined
     const filteredFolder = _.filter(folders, (folder) => {
       const folderName = folder.attributes.name
-      return folderName !== FolderNameTypeConstants.drafts && folderName !== FolderNameTypeConstants.sent
-    }).map((folder, index) => {
-      let label = folder.attributes.name
+      return folderName !== FolderNameTypeConstants.drafts && folderName !== FolderNameTypeConstants.sent && folderName !== FolderNameTypeConstants.deleted
+    }).map((folder) => {
+      const label = folder.attributes.name
 
       const icon = {
         fill: 'defaultMenuItem',
@@ -104,13 +103,6 @@ const ViewMessageScreen: FC<ViewMessageScreenProps> = ({ route, navigation }) =>
         width: theme.fontSizes.MobileBody.fontSize,
         name: 'Folder',
       } as VAIconProps
-
-      if (label === FolderNameTypeConstants.deleted) {
-        label = TRASH_FOLDER_NAME
-        icon.fill = 'error'
-        icon.name = 'Trash'
-        indexOfDeleted = index
-      }
 
       if (label === FolderNameTypeConstants.inbox) {
         icon.fill = 'defaultMenuItem'
@@ -123,11 +115,6 @@ const ViewMessageScreen: FC<ViewMessageScreenProps> = ({ route, navigation }) =>
         icon,
       }
     })
-
-    if (indexOfDeleted !== undefined) {
-      filteredFolder.unshift(filteredFolder.splice(indexOfDeleted, 1)[0])
-    }
-
     return filteredFolder
   }
 


### PR DESCRIPTION
## Description of Change
Removed the trash folder as an option when clicking the move button in the view message.

## Screenshots/Video
Toggle: <details><summary>Before/after:</summary><img src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/ca4c50ca-48dd-4e3f-8490-96376f4e1e98" width="49%" />&nbsp;&nbsp;<img src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/4b420e11-f2df-4ad1-8e68-5332bcf48810" width="49%" /></details>


## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
We need to alter the UI then to only allow deleting for drafts then. Should be as simple as not displaying trash as a option unless they are currently in the drafts folder. Just want to confirm before I make any changes. 

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
