### PR TITLE
bug/6445-theo-AndroidActionSheetTextCutoff

### DIFF
--- a/VAMobile/src/utils/hooks/index.tsx
+++ b/VAMobile/src/utils/hooks/index.tsx
@@ -277,7 +277,7 @@ export function useDestructiveActionSheet(): (props: useDestructiveActionSheetPr
         title: props.title,
         titleTextStyle: { fontWeight: 'bold', textAlign: 'center', color: currentTheme.colors.text.primary },
         message: props.message,
-        messageTextStyle: { textAlign: 'center', color: currentTheme.colors.text.primary },
+        messageTextStyle: { fontWeight: 'normal', textAlign: 'left', color: currentTheme.colors.text.primary },
         textStyle: { color: currentTheme.colors.text.primary },
         destructiveButtonIndex: newDestructiveButtonIndex,
         destructiveColor: currentTheme.colors.text.error,

--- a/VAMobile/src/utils/hooks/index.tsx
+++ b/VAMobile/src/utils/hooks/index.tsx
@@ -277,7 +277,7 @@ export function useDestructiveActionSheet(): (props: useDestructiveActionSheetPr
         title: props.title,
         titleTextStyle: { fontWeight: 'bold', textAlign: 'center', color: currentTheme.colors.text.primary },
         message: props.message,
-        messageTextStyle: { fontWeight: 'normal', textAlign: 'left', color: currentTheme.colors.text.primary },
+        messageTextStyle: { fontWeight: 'normal', textAlign: 'center', color: currentTheme.colors.text.primary },
         textStyle: { color: currentTheme.colors.text.primary },
         destructiveButtonIndex: newDestructiveButtonIndex,
         destructiveColor: currentTheme.colors.text.error,


### PR DESCRIPTION
<!-- NOTE: Please include the related issue number in the PR title, otherwise the changes won't be merged 
into the `staging` branch upon ticket completion. E.g. '[Issue type]/[Issue #]-[Your name]-[Summary of issue]',
where Issue type = bug, feature, spike, CU (code upkeep), etc. -->

## Description of Change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, 
need to know about this PR in order to understand why this PR was created? This could include dependencies 
introduced, changes in behavior, pointers to more detailed documentation. The description should be more 
than a link to an issue.  -->
The text in Action Sheets on Android gets cut off when the `Bold text` option in the display settings is enabled. This is a known [bug](https://github.com/expo/react-native-action-sheet/issues/298) in the `react-native-action-sheet` library. This PR works around the issue by hard-coding the font weight to `normal`, which ensures the font weight for the message text is always `normal`, preventing the text from being cut off. This change doesn't affect iOS, or other Android devices with the `Bold text` setting disabled.

## Screenshots/Video
<!-- Add screenshots or video as needed. Before/after if changes are to be compared by reviewers.
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Toggle: <details><summary></summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>
-->

Before/after: 
<img src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/9042882/35e53534-6c16-4aef-bb34-1b3b930d3f36" width="49%" />&nbsp;&nbsp;<img src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/9042882/00e6f8da-d68f-4b55-ad54-8c93b72dd18a" width="49%" />

## Testing
<!-- What testing was done to verify the changes (local/unit)? What testing remains? Note edge cases, or special
situations that could not be tested during development. -->

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
<!-- What should reviewers look for? Copy/paste Acceptance Criteria from ticket -->
Verify that the message text in Action Sheets isn't cut toff when the `Bold text` setting is enabled on Android. To get to the setting, go to: 

Settings -> Display -> Display size and text -> Toggle `Bold text`


## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [ ] PR is connected to issue(s)
- [ ] Tests are included to cover this change (when possible)
- [ ] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [ ] No secrets or API keys are checked in
- [ ] All imports are absolute (no relative imports)
- [ ] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
