### PR TITLE
bug/6846-theo-DemographicsFetchedBeforeLogin

### DIFF
--- a/VAMobile/src/api/authorizedServices/getAuthorizedServices.tsx
+++ b/VAMobile/src/api/authorizedServices/getAuthorizedServices.tsx
@@ -15,8 +15,9 @@ export const getAuthorizedServices = async (): Promise<UserAuthorizedServicesDat
 /**
  * Returns a query for user demographics
  */
-export const useAuthorizedServices = () => {
+export const useAuthorizedServices = (options?: { enabled?: boolean }) => {
   return useQuery({
+    ...options,
     queryKey: authorizedServicesKeys.authorizedServices,
     queryFn: () => getAuthorizedServices(),
     meta: {

--- a/VAMobile/src/api/demographics/getDemographics.tsx
+++ b/VAMobile/src/api/demographics/getDemographics.tsx
@@ -15,8 +15,9 @@ const getDemographics = async (): Promise<UserDemographics | undefined> => {
 /**
  * Returns a query for user demographics
  */
-export const useDemographics = () => {
+export const useDemographics = (options?: { enabled?: boolean }) => {
   return useQuery({
+    ...options,
     queryKey: demographicsKeys.demographics,
     queryFn: () => getDemographics(),
     meta: {

--- a/VAMobile/src/api/demographics/getDemographics.tsx
+++ b/VAMobile/src/api/demographics/getDemographics.tsx
@@ -15,9 +15,8 @@ const getDemographics = async (): Promise<UserDemographics | undefined> => {
 /**
  * Returns a query for user demographics
  */
-export const useDemographics = (options?: { enabled?: boolean }) => {
+export const useDemographics = () => {
   return useQuery({
-    ...options,
     queryKey: demographicsKeys.demographics,
     queryFn: () => getDemographics(),
     meta: {

--- a/VAMobile/src/api/queryClient.ts
+++ b/VAMobile/src/api/queryClient.ts
@@ -1,8 +1,14 @@
 import { QueryCache, QueryClient } from '@tanstack/react-query'
+
 import { UserAnalytic, logNonFatalErrorToFirebase, setAnalyticsUserProperty } from 'utils/analytics'
 import { isErrorObject } from 'utils/common'
 
 export default new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5000,
+    },
+  },
   queryCache: new QueryCache({
     onSuccess: async (data, query) => {
       const analyticsUserProperty = query?.meta?.analyticsUserProperty as UserAnalytic

--- a/VAMobile/src/screens/HomeScreen/HomeScreen.tsx
+++ b/VAMobile/src/screens/HomeScreen/HomeScreen.tsx
@@ -8,15 +8,10 @@ import { CloseSnackbarOnNavigation } from 'constants/common'
 import { Events } from 'constants/analytics'
 import { HomeStackParamList } from './HomeStackScreens'
 import { NAMESPACE } from 'constants/namespaces'
-import { PersonalInformationState, getProfileInfo } from 'store/slices/personalInformationSlice'
-import { RootState } from 'store'
-import { ScreenIDTypesConstants } from 'store/api/types'
 import { a11yLabelVA } from 'utils/a11yLabel'
 import { logAnalyticsEvent } from 'utils/analytics'
 import { logCOVIDClickAnalytics } from 'store/slices/vaccineSlice'
 import { useAppDispatch, useRouteNavigation, useTheme } from 'utils/hooks'
-import { useDemographics } from 'api/demographics/getDemographics'
-import { useSelector } from 'react-redux'
 import ContactInformationScreen from './ProfileScreen/ContactInformationScreen'
 import ContactVAScreen from './ContactVAScreen/ContactVAScreen'
 import DeveloperScreen from './ProfileScreen/SettingsScreen/DeveloperScreen'
@@ -42,16 +37,6 @@ export const HomeScreen: FC<HomeScreenProps> = ({ navigation }) => {
 
   const navigateTo = useRouteNavigation()
   const theme = useTheme()
-  const { profile } = useSelector<RootState, PersonalInformationState>((state) => state.personalInformation)
-  const { data: demographics, isLoading: loadingDemographics } = useDemographics()
-  const name = loadingDemographics ? '' : demographics?.preferredName || profile?.firstName || ''
-
-  useEffect(() => {
-    // Fetch the profile information
-    if (name === '') {
-      dispatch(getProfileInfo(ScreenIDTypesConstants.PROFILE_SCREEN_ID))
-    }
-  }, [dispatch, name])
 
   useEffect(() => {
     navigation.setOptions({

--- a/VAMobile/src/screens/SyncScreen/SyncScreen.test.tsx
+++ b/VAMobile/src/screens/SyncScreen/SyncScreen.test.tsx
@@ -132,20 +132,6 @@ context('SyncScreen', () => {
 
   describe('sync completion', () => {
     it('should complete the sync when all loading is finished', async () => {
-      jest.mock('../../api/demographics/getDemographics', () => {
-        let original = jest.requireActual('../../api/demographics/getDemographics')
-        return {
-          ...original,
-          useDemographics: () => ({
-            status: "success",
-            data: {
-              genderIdentity: '',
-              preferredName: '',
-            }
-          }),
-        }
-      })
-
       initializeTestInstance(false, false, false, true, false)
       await waitFor(async () => {
         expect(completeSync).toHaveBeenCalled()

--- a/VAMobile/src/screens/SyncScreen/SyncScreen.tsx
+++ b/VAMobile/src/screens/SyncScreen/SyncScreen.tsx
@@ -33,7 +33,7 @@ const SyncScreen: FC<SyncScreenProps> = () => {
   const { preloadComplete: militaryHistoryLoaded, loading: militaryHistoryLoading } = useSelector<RootState, MilitaryServiceState>((s) => s.militaryService)
   const { preloadComplete: disabilityRatingLoaded, loading: disabilityRatingLoading } = useSelector<RootState, DisabilityRatingState>((s) => s.disabilityRating)
   const { data: userAuthorizedServices, isLoading: loadingUserAuthorizedServices } = useAuthorizedServices()
-  const { isFetched: demographicsLoaded } = useDemographics()
+  const { isFetched: demographicsLoaded } = useDemographics({ enabled: loggedIn })
 
   const [displayMessage, setDisplayMessage] = useState('')
 

--- a/VAMobile/src/screens/SyncScreen/SyncScreen.tsx
+++ b/VAMobile/src/screens/SyncScreen/SyncScreen.tsx
@@ -12,7 +12,6 @@ import { RootState } from 'store'
 import { testIdProps } from 'utils/accessibility'
 import { useAppDispatch, useOrientation, useTheme } from 'utils/hooks'
 import { useAuthorizedServices } from 'api/authorizedServices/getAuthorizedServices'
-import { useDemographics } from 'api/demographics/getDemographics'
 import colors from 'styles/themes/VAColors'
 
 export type SyncScreenProps = Record<string, unknown>
@@ -81,7 +80,7 @@ const SyncScreen: FC<SyncScreenProps> = () => {
     }
 
     const finishSyncingMilitaryHistory = !loadingUserAuthorizedServices && (!userAuthorizedServices?.militaryServiceHistory || militaryHistoryLoaded)
-    if (personalInformationLoaded && finishSyncingMilitaryHistory && loggedIn && !loggingOut && disabilityRatingLoaded && demographicsLoaded) {
+    if (personalInformationLoaded && finishSyncingMilitaryHistory && loggedIn && !loggingOut && disabilityRatingLoaded) {
       dispatch(completeSync())
     }
   }, [
@@ -95,7 +94,6 @@ const SyncScreen: FC<SyncScreenProps> = () => {
     t,
     disabilityRatingLoaded,
     syncing,
-    demographicsLoaded,
   ])
 
   return (

--- a/VAMobile/src/screens/SyncScreen/SyncScreen.tsx
+++ b/VAMobile/src/screens/SyncScreen/SyncScreen.tsx
@@ -32,8 +32,7 @@ const SyncScreen: FC<SyncScreenProps> = () => {
   const { preloadComplete: personalInformationLoaded, loading: personalInformationLoading } = useSelector<RootState, PersonalInformationState>((s) => s.personalInformation)
   const { preloadComplete: militaryHistoryLoaded, loading: militaryHistoryLoading } = useSelector<RootState, MilitaryServiceState>((s) => s.militaryService)
   const { preloadComplete: disabilityRatingLoaded, loading: disabilityRatingLoading } = useSelector<RootState, DisabilityRatingState>((s) => s.disabilityRating)
-  const { data: userAuthorizedServices, isLoading: loadingUserAuthorizedServices } = useAuthorizedServices()
-  const { isFetched: demographicsLoaded } = useDemographics({ enabled: loggedIn })
+  const { data: userAuthorizedServices, isLoading: loadingUserAuthorizedServices } = useAuthorizedServices({ enabled: loggedIn })
 
   const [displayMessage, setDisplayMessage] = useState('')
 


### PR DESCRIPTION
<!-- NOTE: Please include the related issue number in the PR title, otherwise the changes won't be merged 
into the `staging` branch upon ticket completion. E.g. '[Issue type]/[Issue #]-[Your name]-[Summary of issue]',
where Issue type = bug, feature, spike, CU (code upkeep), etc. -->

## Description of Change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, 
need to know about this PR in order to understand why this PR was created? This could include dependencies 
introduced, changes in behavior, pointers to more detailed documentation. The description should be more 
than a link to an issue.  -->
Demographics data is currently being fetched before login is completed, which is causing JWT malformed errors in Sentry. This is because the access token hasn't been set if login isn't complete. We actually don't need to fetch demographics info on the Sync screen anymore because the greeting on the Home screen containing the user's preferred name was replaced with the veteran status card. 

The issue with the demographics endpoint is also happening with authorized services endpoint, so I updated the `useAuthorizedServices` hook on the Sync screen to be dependent on login being complete before running. 

After making the authorized services query dependent on login, I noticed a duplicate successful API call being made. This due to the default stale time being `0`  in React Query, so it's refetches the data from the API again whenever the query is referenced, which isn't ideal when multiple components that use the query are rendered closely together. I noticed the same issue happening on the [contact info screen](https://github.com/department-of-veterans-affairs/va-mobile-app/pull/6733#discussion_r1339362211). I fixed this in this PR by setting the stale time to 5 seconds for all queries. We probably need to figure out what the ideal default stale time should be, but for now 5 seconds will at least prevent duplicate calls from being made during renders.

## Screenshots/Video
<!-- Add screenshots or video as needed. Before/after if changes are to be compared by reviewers.
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Toggle: <details><summary></summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>
-->
N/A

## Testing
<!-- What testing was done to verify the changes (local/unit)? What testing remains? Note edge cases, or special
situations that could not be tested during development. -->

Tested locally with Charles Proxxy.

- [ ] Tested on iOS <!-- simulator is fine -->
- [ ] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
<!-- What should reviewers look for? Copy/paste Acceptance Criteria from ticket -->
- [ ] The demographics endpoint is no longer called when signing in
- [ ] The authorized services endpoint is only called once after sign in is complete

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [ ] PR is connected to issue(s)
- [ ] Tests are included to cover this change (when possible)
- [ ] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [ ] No secrets or API keys are checked in
- [ ] All imports are absolute (no relative imports)
- [ ] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
