### PR TITLE
bug/6480-Dylan-ProperlyComparingDates

### DIFF
--- a/VAMobile/src/utils/formattingUtils.ts
+++ b/VAMobile/src/utils/formattingUtils.ts
@@ -68,7 +68,7 @@ export const getFormattedDateTimeYear = (dateTime: string): string => {
  */
 export const getFormattedMessageTime = (dateTime: string): string => {
   const date = DateTime.fromISO(dateTime)
-  if (DateTime.now().minus({ hours: 24 }) < date) {
+  if (DateTime.now().day === date.day && DateTime.now().month === date.month && date.year === DateTime.now().year) {
     return date.toFormat('t')
   } else {
     return date.toFormat('D')

--- a/VAMobile/src/utils/formattingUtils.ts
+++ b/VAMobile/src/utils/formattingUtils.ts
@@ -68,7 +68,7 @@ export const getFormattedDateTimeYear = (dateTime: string): string => {
  */
 export const getFormattedMessageTime = (dateTime: string): string => {
   const date = DateTime.fromISO(dateTime)
-  if (DateTime.now().day === date.day && DateTime.now().month === date.month && date.year === DateTime.now().year) {
+  if (DateTime.now().day === date.day && DateTime.now().month === date.month && DateTime.now().year === date.year) {
     return date.toFormat('t')
   } else {
     return date.toFormat('D')


### PR DESCRIPTION
## Description of Change
Changed the date comparison from being 24 hours to looking at the day, month, and year to see if the message was sent on a different day to take care of instances of a user sending a message for example at 11pm and then coming in the next day and seeing 11pm instead of yesterdays date.

## Screenshots/Video
After:


<img width="281" alt="Screenshot 2023-09-27 at 11 58 05 AM" src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/b58d7793-fc07-4f26-bd2c-503f06a2e291">

## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
Timestamps for secure messages should be accurate

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
