### PR TITLE
finished

### DIFF
--- a/VAMobile/src/App.tsx
+++ b/VAMobile/src/App.tsx
@@ -40,7 +40,7 @@ import { isIOS } from 'utils/platform'
 import { linking } from 'constants/linking'
 import { profileAddressType } from 'screens/HomeScreen/ProfileScreen/ContactInformationScreen/AddressSummary'
 import { updateFontScale, updateIsVoiceOverTalkBackRunning } from './utils/accessibility'
-import { useAppDispatch } from 'utils/hooks'
+import { useAppDispatch, useIsScreenReaderEnabled } from 'utils/hooks'
 import { useColorScheme } from 'styles/themes/colorScheme'
 import { useHeaderStyles, useTopPaddingAsHeaderStyles } from 'utils/hooks/headerStyles'
 import BiometricsPreferenceScreen from 'screens/BiometricsPreferenceScreen'
@@ -164,6 +164,7 @@ export const AuthGuard: FC = () => {
   // This is to simulate SafeArea top padding through the header for technically header-less screens (no title, no back buttons)
   const topPaddingAsHeaderStyles = useTopPaddingAsHeaderStyles()
   const [currNewState, setCurrNewState] = useState('active')
+  const screenReaderEnabled = useIsScreenReaderEnabled()
 
   const snackBarProps: Partial<ToastProps> = {
     duration: SnackBarConstants.duration,
@@ -188,10 +189,9 @@ export const AuthGuard: FC = () => {
   }, [isVoiceOverTalkBackRunning, dispatch, currNewState])
 
   useEffect(() => {
-    // only run on app load
     dispatch(sendUsesLargeTextAnalytics())
     dispatch(sendUsesScreenReaderAnalytics())
-  }, [dispatch])
+  }, [dispatch, screenReaderEnabled])
 
   useEffect(() => {
     // Listener for the current app state, updates isVoiceOverTalkBackRunning when app state is active and voice over/talk back


### PR DESCRIPTION
## Description of Change
Changed the screen reader analytics from firing on app launch to firing on app launch and when screen reader is turned on/off

## Screenshots/Video
N/A

## Testing
Yarn Test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
App analytics tracks all screen reader users regardless if they turn it on before or after opening the app.

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
