### PR TITLE
6736-chris-android-firefox-login-fix

### DIFF
--- a/VAMobile/android/app/src/main/java/gov/va/mobileapp/native_modules/CustomTabsIntentModule.kt
+++ b/VAMobile/android/app/src/main/java/gov/va/mobileapp/native_modules/CustomTabsIntentModule.kt
@@ -82,6 +82,9 @@ class CustomTabsIntentModule(private val context: ReactApplicationContext) :
                             }
                             .build()
 
+            // Prevent login issues on Android when Firefox is the default browser
+            customTabsIntent.intent.flags = FLAG_ACTIVITY_NEW_TASK
+
             context.currentActivity?.apply { customTabsIntent.launchUrl(this, authURI) }
             promise.resolve(true)
         } catch (e: Throwable) {


### PR DESCRIPTION
<!-- NOTE: Please include the related issue number in the PR title, otherwise the changes won't be merged 
into the `staging` branch upon ticket completion. E.g. '[Issue type]/[Issue #]-[Your name]-[Summary of issue]',
where Issue type = bug, feature, spike, CU (code upkeep), etc. -->

## Description of Change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, 
need to know about this PR in order to understand why this PR was created? This could include dependencies 
introduced, changes in behavior, pointers to more detailed documentation. The description should be more 
than a link to an issue.  -->

It appears that with Firefox as the default browser and android:launchMode="singleTop", login is successful but a separate instance of the app is created. There's then an instance of the app that the user doesn't see where the user is logged in successfully. But in the instance the user does see, it appears as if nothing happened. Also, a deep linking error is thrown because App.tsx gets rendered once in one instance and again in the other instance.

This PR adds the FLAG_ACTIVITY_NEW_TASK flag to the customTabsIntent that displays the login screen. The flag prevents the customTabsIntent from creating a new instance of the app.

## Screenshots/Video
<!-- Add screenshots or video as needed. Before/after if changes are to be compared by reviewers.
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Toggle: <details><summary></summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>
-->

Successful login on Android with Firefox as default browser:

[ff-login.webm](https://github.com/department-of-veterans-affairs/va-mobile-app/assets/5805150/1083dd58-383b-4769-8194-4fd2a0dfe58f)


Switching apps on Android with Firefox, without losing the custom tab:

[firefox-switch-apps.webm](https://github.com/department-of-veterans-affairs/va-mobile-app/assets/5805150/dd140f13-49cf-4563-95ab-67159c69ee77)

Successful login on Android with Chrome as default browser:

[android-chrome.webm](https://github.com/department-of-veterans-affairs/va-mobile-app/assets/5805150/e8e9472c-c6c1-410c-80fd-3a0b389a7034)


## Testing
<!-- What testing was done to verify the changes (local/unit)? What testing remains? Note edge cases, or special
situations that could not be tested during development. -->

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
<!-- What should reviewers look for? Copy/paste Acceptance Criteria from ticket -->

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [ ] PR is connected to issue(s)
- [ ] Tests are included to cover this change (when possible)
- [ ] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [ ] No secrets or API keys are checked in
- [ ] All imports are absolute (no relative imports)
- [ ] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
