### PR TITLE
bug/5037-ClaimIconLargeFontNonScalingSize

### DIFF
--- a/VAMobile/src/utils/claims.tsx
+++ b/VAMobile/src/utils/claims.tsx
@@ -262,11 +262,11 @@ export const deletePhoto = (deleteCallbackIfUri: (response: Asset[]) => void, de
  * @param fs - fontscale function
  */
 export const getIndicatorCommonProps = (fs: (val: number) => number) => {
-  const indicatorDiameter = 30
+  const indicatorDiameter = fs(30)
   return {
-    height: fs(indicatorDiameter),
-    width: fs(indicatorDiameter),
-    borderRadius: fs(indicatorDiameter),
+    height: indicatorDiameter > 35 ? 35 : indicatorDiameter,
+    width: indicatorDiameter > 35 ? 35 : indicatorDiameter,
+    borderRadius: indicatorDiameter > 35 ? 35 : indicatorDiameter,
     justifyContent: 'center',
     textAlign: 'center',
     alignItems: 'center',
@@ -284,12 +284,12 @@ export const getIndicatorValue = (number: number, useCheckMark: boolean): ReactE
   if (useCheckMark) {
     return (
       <Box justifyContent={'center'} alignItems={'center'}>
-        <VAIcon width={15} height={15} name={'CheckMark'} fill="#fff" />
+        <VAIcon width={15} height={15} name={'CheckMark'} fill="#fff" preventScaling={true} />
       </Box>
     )
   } else {
     return (
-      <TextView variant="ClaimPhase" textAlign={'center'} mt={-2.5}>
+      <TextView variant="ClaimPhase" textAlign={'center'} mt={-2.5} allowFontScaling={false}>
         {number}
       </TextView>
     )


### PR DESCRIPTION
## Description of Change
Locked the claims icons to size 35 when scaled to larger fonts

## Screenshots/Video
Toggle: <details><summary>Before:After</summary><img src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/b4bc53e7-61d0-4b16-ba5b-2e4a56788931" width="49%" />&nbsp;&nbsp;<img src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/c9caed98-5709-4f5c-bccb-0c8dd15051ee" width="49%" /></details>

After:

![Screenshot 2023-10-10 at 1 15 55 PM](https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/1d9dff8c-ddf4-4c5e-a2da-905793c129d2)


## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
<!-- What should reviewers look for? Copy/paste Acceptance Criteria from ticket -->

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
