### PR TITLE
bug/6907-Dylan-FixFillDateSortBy

### DIFF
--- a/VAMobile/src/store/slices/prescriptionSlice.ts
+++ b/VAMobile/src/store/slices/prescriptionSlice.ts
@@ -141,7 +141,7 @@ export const filterAndSortPrescriptions =
         break
       case PrescriptionSortOptionConstants.REFILL_DATE:
         sortedList = sortBy(filteredList, (a) => {
-          return new Date(a.attributes.refillDate || '')
+          return new Date(a.attributes.refillDate || 0)
         })
         break
     }


### PR DESCRIPTION
## Description of Change
Fixed sort by fill date properly supplying 0 as the default instead of ''. This changed it from a date string comparison to a number comparison when comparing dates which then accurately sorts them.

## Screenshots/Video

<img width="562" alt="Screenshot 2023-10-10 at 6 34 30 PM" src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/4c6ebbda-d092-4abe-8b5e-c801a441e1da">
<img width="562" alt="Screenshot 2023-10-10 at 6 34 39 PM" src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/b2bf459c-1f73-45f2-bcb9-7815a4643f2d">

## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
When sorting by fill date that the dates appear in the right order when selecting
Oldest to Newest
Newest to Oldest

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
