### PR TITLE
bug/5107-Dylan-SnackbarScrollView

### DIFF
--- a/VAMobile/src/components/SnackBar.tsx
+++ b/VAMobile/src/components/SnackBar.tsx
@@ -4,7 +4,7 @@ import { ToastProps } from 'react-native-toast-notifications/lib/typescript/toas
 import { useFocusEffect } from '@react-navigation/native'
 import React, { FC } from 'react'
 
-import { Box, TextViewProps } from 'components'
+import { Box, TextViewProps, VAScrollView } from 'components'
 import { BoxProps } from './Box'
 import { NAMESPACE } from 'constants/namespaces'
 import { triggerHaptic } from 'utils/haptics'
@@ -30,6 +30,7 @@ const SnackBar: FC<ToastProps> = (toast) => {
   const { colors: themeColor } = useTheme()
   const [focusRef, setFocus] = useAccessibilityFocus<View>()
   const { t } = useTranslation(NAMESPACE.COMMON)
+  const windowHeight = useWindowDimensions().height
   const fontScale = useWindowDimensions().fontScale
 
   useFocusEffect(setFocus)
@@ -140,14 +141,18 @@ const SnackBar: FC<ToastProps> = (toast) => {
   return (
     <SafeAreaView edges={['left', 'right']} style={{ ...safeViewStyle }}>
       <Box {...mainContainerProps}>
-        <View accessible={true} accessibilityRole={'alert'} ref={focusRef}>
-          <Box {...messageContainerProps}>
-            <Box {...iconWrapperBoxProps}>
-              <VAIcon {...snackBarIconProps} />
-            </Box>
-            <TextView {...messageProp}>{message}</TextView>
-          </Box>
-        </View>
+        <Box height={fontScale >= 3 ? windowHeight * 0.45 : undefined}>
+          <VAScrollView backgroundColor="snackbar">
+            <View accessible={true} accessibilityRole={'alert'} ref={focusRef}>
+              <Box {...messageContainerProps}>
+                <Box {...iconWrapperBoxProps}>
+                  <VAIcon {...snackBarIconProps} />
+                </Box>
+                <TextView {...messageProp}>{message}</TextView>
+              </Box>
+            </View>
+          </VAScrollView>
+        </Box>
         <Box {...btnContainerProps}>
           {!isUndo && (
             <TouchableOpacity onPress={onActionPress} style={confirmBtnStlye} accessible={true} accessibilityRole={'button'}>


### PR DESCRIPTION
## Description of Change
Added a scrollview to snackbar that scales with varying screen heights based on fontScale like other parts of the snackbar.

## Screenshots/Video


https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/43ef4a32-eb50-4d13-9e7c-712e2dd2a9d0


## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
Discussed with FE and QA. Implement scrollview on snackbars, and keep back-button wrapping as is.

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
