### PR TITLE
CU/5373-Dylan-DismissSnackbarOnNav

### DIFF
--- a/VAMobile/src/constants/common.ts
+++ b/VAMobile/src/constants/common.ts
@@ -1,5 +1,3 @@
-import { includes } from 'underscore'
-
 import { Events } from './analytics'
 import { logAnalyticsEvent } from 'utils/analytics'
 
@@ -33,42 +31,12 @@ export const SnackBarConstants: {
   duration: 900000,
 }
 
-const screensToCloseSnackbarOnNavigation = [
-  'AppealDetailsScreen',
-  'Appointments',
-  'AskForClaimDecision',
-  'ClaimDetails',
-  'ClaimDetailsScreen',
-  'ClaimLettersScreen',
-  'StartNewMessage',
-  'DirectDeposit',
-  'EditDirectDeposit',
-  'EditDraft',
-  'EditPhoneNumber',
-  'FileRequest',
-  'FolderMessages',
-  'PersonalInformation',
-  'ContactInformation',
-  'ReplyMessage',
-  'SecureMessaging',
-  'SelectFile',
-  'TakePhotos',
-  'UpcomingAppointmentDetails',
-  'UploadFile',
-  'UploadOrAddPhotos',
-  'ViewMessageScreen',
-  'LettersOverview',
-]
-
 export const CloseSnackbarOnNavigation = (screenName: string | undefined) => {
   if (screenName) {
-    const screen = screenName.split('-')[0]
-    if (includes(screensToCloseSnackbarOnNavigation, screen)) {
-      if (!snackBar) {
-        logAnalyticsEvent(Events.vama_snackbar_null(`CloseSnackbarOnNavigation - ${screen}`))
-      }
-      snackBar?.hideAll()
+    if (!snackBar) {
+      logAnalyticsEvent(Events.vama_snackbar_null(`CloseSnackbarOnNavigation - ${screenName.split('-')[0]}`))
     }
+    snackBar?.hideAll()
   }
 }
 


### PR DESCRIPTION
## Description of Change
Removed the screen check to dismiss the snackbar since every screen dismissed the snackbar on navigation

## Screenshots/Video


https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/ab4cea3a-2fd6-484d-a6b7-2c08d05d3019



## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
Investigate whether we can bypass this array for dismissing snackbars. Having to constantly update this seems potentially unnecessary?

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
