### PR TITLE
bug/3943-Dylan-RX-MultiLineStatusCutoffLargeFontFix

### DIFF
--- a/VAMobile/src/components/LabelTag.tsx
+++ b/VAMobile/src/components/LabelTag.tsx
@@ -1,4 +1,4 @@
-import { Pressable, PressableProps } from 'react-native'
+import { Pressable, PressableProps, useWindowDimensions } from 'react-native'
 import React, { FC } from 'react'
 
 import { useTheme } from 'utils/hooks'
@@ -40,9 +40,10 @@ export type LabelTagProps = {
 /**Common component to show a text inside a tag*/
 const LabelTag: FC<LabelTagProps> = ({ text, labelType, onPress, a11yHint, a11yLabel }) => {
   const theme = useTheme()
+  const fontScale = useWindowDimensions().fontScale
 
   const textView = (
-    <TextView flexWrap={'wrap'} color={'labelTag'} variant={'LabelTag'} px={12} py={4}>
+    <TextView flexWrap={'wrap'} color={'labelTag'} variant={'LabelTag'} pl={fontScale >= 2 ? 30 : 12} pr={fontScale >= 2 ? 8 : 12} py={fontScale >= 2 ? 8 : 4}>
       {text}
     </TextView>
   )
@@ -96,9 +97,9 @@ const LabelTag: FC<LabelTagProps> = ({ text, labelType, onPress, a11yHint, a11yL
       name: 'Info',
       fill: 'tagInfoIcon',
       fill2: 'transparent',
-      height: 16,
-      width: 16,
-      mr: 10,
+      height: fontScale >= 2 ? 10 : 16,
+      width: fontScale >= 2 ? 10 : 16,
+      mr: fontScale >= 2 ? 5 : 10,
     }
 
     return (

--- a/VAMobile/src/components/LabelTag.tsx
+++ b/VAMobile/src/components/LabelTag.tsx
@@ -41,9 +41,9 @@ export type LabelTagProps = {
 const LabelTag: FC<LabelTagProps> = ({ text, labelType, onPress, a11yHint, a11yLabel }) => {
   const theme = useTheme()
   const fontScale = useWindowDimensions().fontScale
-
+  const adjustSize = fontScale >= 2
   const textView = (
-    <TextView flexWrap={'wrap'} color={'labelTag'} variant={'LabelTag'} pl={fontScale >= 2 ? 30 : 12} pr={fontScale >= 2 ? 8 : 12} py={fontScale >= 2 ? 8 : 4}>
+    <TextView flexWrap={'wrap'} color={'labelTag'} variant={'LabelTag'} pl={adjustSize ? 30 : 12} pr={adjustSize ? 8 : 12} py={adjustSize ? 8 : 4}>
       {text}
     </TextView>
   )
@@ -97,9 +97,9 @@ const LabelTag: FC<LabelTagProps> = ({ text, labelType, onPress, a11yHint, a11yL
       name: 'Info',
       fill: 'tagInfoIcon',
       fill2: 'transparent',
-      height: fontScale >= 2 ? 10 : 16,
-      width: fontScale >= 2 ? 10 : 16,
-      mr: fontScale >= 2 ? 5 : 10,
+      height: adjustSize ? 10 : 16,
+      width: adjustSize ? 10 : 16,
+      mr: adjustSize ? 5 : 10,
     }
 
     return (


### PR DESCRIPTION
## Description of Change
adjusted Label tag's padding, and the info icon size to scale with fontScale differently in order to make sure the text is prioritized and inside the bubble so there is no cut off edges making it hard to read.

## Screenshots/Video
Toggle: <details><summary>Before/after:</summary><img src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/c697124a-c9cc-473d-994b-8515798089ca" width="49%" />&nbsp;&nbsp;<img src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/8be7b01a-f7c9-4e02-8199-e4332c45e954" width="49%" /></details>

## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
Text should stay within the bounds of the pill no matter the font size

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
