### PR TITLE
bug/6965-Dylan-MissingTTYDMDC

### DIFF
--- a/VAMobile/e2e/tests/MilitaryInformation.e2e.ts
+++ b/VAMobile/e2e/tests/MilitaryInformation.e2e.ts
@@ -53,10 +53,10 @@ describe('Military Information Screen', () => {
 		await expect(element(by.label(MilitaryInformationE2eIdConstants.SERVICE_INFORMATION_INCORRECT_BODY_LABEL_1))).toExist()
 		await expect(element(by.label(MilitaryInformationE2eIdConstants.SERVICE_INFORMATION_INCORRECT_BODY_LABEL_2))).toExist()
 		await expect(element(by.label(MilitaryInformationE2eIdConstants.SERVICE_INFORMATION_INCORRECT_BODY_LABEL_3))).toExist()
-		await expect(element(by.id('incorrectServiceDMDCNumberTestID'))).toExist()
+		await expect(element(by.id('CallVATestID'))).toExist()
 		await element(by.id('IncorrectServiceTestID')).swipe('up')
 		if (device.getPlatform() === 'android') {
-			await element(by.id('incorrectServiceDMDCNumberTestID')).tap()
+			await element(by.id('CallVATestID')).tap()
 			await setTimeout(5000)
 			var tempPath = await device.takeScreenshot('AndroidCallingScreen')
 			await device.launchApp({newInstance: false})

--- a/VAMobile/src/screens/HomeScreen/ProfileScreen/MilitaryInformationScreen/IncorrectServiceInfo/IncorrectServiceInfo.tsx
+++ b/VAMobile/src/screens/HomeScreen/ProfileScreen/MilitaryInformationScreen/IncorrectServiceInfo/IncorrectServiceInfo.tsx
@@ -5,7 +5,6 @@ import React, { FC } from 'react'
 import { Box, ClickToCallPhoneNumber, LargePanel, TextView } from 'components'
 import { HomeStackParamList } from 'screens/HomeScreen/HomeStackScreens'
 import { NAMESPACE } from 'constants/namespaces'
-import { a11yLabelID } from 'utils/a11yLabel'
 import { displayedTextPhoneNumber } from 'utils/formattingUtils'
 import { useTheme } from 'utils/hooks'
 
@@ -39,7 +38,7 @@ const IncorrectServiceInfo: FC<IncorrectServiceInfoScreenProps> = () => {
         <TextView accessibilityLabel={t('militaryInformation.incorrectServiceInfo.bodyA11yLabel.3')} variant="MobileBody" paragraphSpacing={true}>
           {t('militaryInformation.incorrectServiceInfo.body.3')}
         </TextView>
-        <ClickToCallPhoneNumber phone={t('8005389552')} displayedText={displayedTextPhoneNumber(t('8005389552'))} a11yLabel={a11yLabelID(t('8005389552'))} />
+        <ClickToCallPhoneNumber phone={t('8005389552')} displayedText={displayedTextPhoneNumber(t('8005389552'))} />
       </Box>
     </LargePanel>
   )

--- a/VAMobile/src/screens/HomeScreen/ProfileScreen/MilitaryInformationScreen/IncorrectServiceInfo/IncorrectServiceInfo.tsx
+++ b/VAMobile/src/screens/HomeScreen/ProfileScreen/MilitaryInformationScreen/IncorrectServiceInfo/IncorrectServiceInfo.tsx
@@ -2,7 +2,7 @@ import { StackScreenProps } from '@react-navigation/stack/lib/typescript/src/typ
 import { useTranslation } from 'react-i18next'
 import React, { FC } from 'react'
 
-import { Box, ClickForActionLink, LargePanel, LinkTypeOptionsConstants, TextView } from 'components'
+import { Box, ClickToCallPhoneNumber, LargePanel, TextView } from 'components'
 import { HomeStackParamList } from 'screens/HomeScreen/HomeStackScreens'
 import { NAMESPACE } from 'constants/namespaces'
 import { a11yLabelID } from 'utils/a11yLabel'
@@ -39,13 +39,7 @@ const IncorrectServiceInfo: FC<IncorrectServiceInfoScreenProps> = () => {
         <TextView accessibilityLabel={t('militaryInformation.incorrectServiceInfo.bodyA11yLabel.3')} variant="MobileBody" paragraphSpacing={true}>
           {t('militaryInformation.incorrectServiceInfo.body.3')}
         </TextView>
-        <ClickForActionLink
-          testID="incorrectServiceDMDCNumberTestID"
-          displayedText={displayedTextPhoneNumber(t('8005389552'))}
-          a11yLabel={a11yLabelID(t('8005389552'))}
-          numberOrUrlLink={t('8005389552')}
-          linkType={LinkTypeOptionsConstants.call}
-        />
+        <ClickToCallPhoneNumber phone={t('8005389552')} displayedText={displayedTextPhoneNumber(t('8005389552'))} a11yLabel={a11yLabelID(t('8005389552'))}/>
       </Box>
     </LargePanel>
   )

--- a/VAMobile/src/screens/HomeScreen/ProfileScreen/MilitaryInformationScreen/IncorrectServiceInfo/IncorrectServiceInfo.tsx
+++ b/VAMobile/src/screens/HomeScreen/ProfileScreen/MilitaryInformationScreen/IncorrectServiceInfo/IncorrectServiceInfo.tsx
@@ -39,7 +39,7 @@ const IncorrectServiceInfo: FC<IncorrectServiceInfoScreenProps> = () => {
         <TextView accessibilityLabel={t('militaryInformation.incorrectServiceInfo.bodyA11yLabel.3')} variant="MobileBody" paragraphSpacing={true}>
           {t('militaryInformation.incorrectServiceInfo.body.3')}
         </TextView>
-        <ClickToCallPhoneNumber phone={t('8005389552')} displayedText={displayedTextPhoneNumber(t('8005389552'))} a11yLabel={a11yLabelID(t('8005389552'))}/>
+        <ClickToCallPhoneNumber phone={t('8005389552')} displayedText={displayedTextPhoneNumber(t('8005389552'))} a11yLabel={a11yLabelID(t('8005389552'))} />
       </Box>
     </LargePanel>
   )


### PR DESCRIPTION
## Description of Change
Added 711 missing tty to the incorrect service info screen

## Screenshots/Video
Toggle: <details><summary>Before/after: </summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>


## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
 Locate correct number
 Add link in line with other phone number/TTY combinations in the app
Always a good place to start is actually just looking on web. Per this screenshot, TTY for DMDC is 711

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
