### PR TITLE
bug/6789-Dylan-SnakbarNullHackyFix

### DIFF
--- a/VAMobile/src/App.tsx
+++ b/VAMobile/src/App.tsx
@@ -15,7 +15,7 @@ import { useTranslation } from 'react-i18next'
 import { utils } from '@react-native-firebase/app'
 import KeyboardManager from 'react-native-keyboard-manager'
 import React, { FC, useEffect, useRef, useState } from 'react'
-import Toast from 'react-native-toast-notifications'
+import Toast, { useToast } from 'react-native-toast-notifications'
 import ToastContainer from 'react-native-toast-notifications'
 import analytics from '@react-native-firebase/analytics'
 import crashlytics from '@react-native-firebase/crashlytics'
@@ -293,6 +293,8 @@ export const AppTabs: FC = () => {
 
 export const AuthedApp: FC = () => {
   const headerStyles = useHeaderStyles()
+  const toast = useToast()
+  const [message, setMessage] = useState(null)
   const { initialUrl } = useSelector<RootState, NotificationsState>((state) => state.notifications)
 
   const homeScreens = getHomeScreens()
@@ -307,6 +309,16 @@ export const AuthedApp: FC = () => {
       Linking.openURL(initialUrl)
     }
   }, [initialUrl])
+
+  useEffect(() => {
+    //initially Toast is set to null until it is first used. So when we call showsnackbar it calls hideall on a null reference. this should first set that reference
+    if (message) {
+      toast.show(message, {
+        type: 'danger',
+      })
+      setMessage(null)
+    }
+  }, [toast])
 
   return (
     <>


### PR DESCRIPTION
## Description of Change
According to this issue https://github.com/arnnis/react-native-toast-notifications/issues/127 that on startup it often has a null ref and isn't set until the first time it is used.

<Toast {...snackBarProps} ref={(ref) => ((global.snackBar as ToastContainer | null) = ref)} offsetBottom={bottomOffset} />

So when trying to hide a null reference it crashes. Since this is no longer supported by the author the hacky solution I added to the app.tsx which should generate the reference on app launch for the container. I tested it and made sure no actual toast was displayed on fresh install/launch.

It is hard to determine if this will actually fix the issue if for some reason the reference is being set null elsewhere for whatever reason. Only way I can think of to determine this is to release this and see if the logged events disappears on the new version.

## Screenshots/Video
N/A

## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
Snackbar ref shouldn't be null

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
