### PR TITLE
finished

### DIFF
--- a/VAMobile/jest/testSetup.ts
+++ b/VAMobile/jest/testSetup.ts
@@ -149,12 +149,6 @@ jest.mock('@react-native-cookies/cookies', () => {
   }
 })
 
-jest.mock('@react-native-community/clipboard', () => {
-  return {
-    setString: jest.fn(),
-  }
-})
-
 jest.mock('@react-navigation/native', () => {
   const original = jest.requireActual('@react-navigation/native')
   return {

--- a/VAMobile/package.json
+++ b/VAMobile/package.json
@@ -43,7 +43,6 @@
     "@department-of-veterans-affairs/mobile-component-library": "0.0.22",
     "@expo/react-native-action-sheet": "^3.13.0",
     "@react-native-async-storage/async-storage": "^1.18.1",
-    "@react-native-community/clipboard": "^1.5.1",
     "@react-native-cookies/cookies": "^6.2.1",
     "@react-native-firebase/analytics": "^14.5.0",
     "@react-native-firebase/app": "^14.5.0",

--- a/VAMobile/src/screens/HomeScreen/ProfileScreen/SettingsScreen/DeveloperScreen/DeveloperScreen.tsx
+++ b/VAMobile/src/screens/HomeScreen/ProfileScreen/SettingsScreen/DeveloperScreen/DeveloperScreen.tsx
@@ -1,13 +1,11 @@
 import { pick } from 'underscore'
 import { useTranslation } from 'react-i18next'
 import AsyncStorage from '@react-native-async-storage/async-storage'
-import Clipboard from '@react-native-community/clipboard'
 import React, { FC, useEffect, useRef, useState } from 'react'
-
-import { Box, ButtonTypesConstants, FeatureLandingTemplate, TextArea, TextView, VAButton, VATextInput } from 'components'
 
 import { AnalyticsState } from 'store/slices'
 import { AuthState, debugResetFirstTimeLogin } from 'store/slices/authSlice'
+import { Box, ButtonTypesConstants, FeatureLandingTemplate, TextArea, TextView, VAButton, VATextInput } from 'components'
 import { DEVICE_ENDPOINT_SID, NotificationsState } from 'store/slices/notificationSlice'
 import { FeatureConstants, getLocalVersion, getStoreVersion, getVersionSkipped, overrideLocalVersion, setVersionSkipped } from 'utils/homeScreenAlerts'
 import { HomeStackParamList } from 'screens/HomeScreen/HomeStackScreens'
@@ -92,10 +90,6 @@ const DeveloperScreen: FC<DeveloperScreenSettingsScreenProps> = ({ navigation })
   const [deviceAppSid, setDeviceAppSid] = useState<string>('')
   getAsyncStoredData(DEVICE_ENDPOINT_SID, setDeviceAppSid)
 
-  const onCopy = (copy: string): void => {
-    Clipboard.setString(copy)
-  }
-
   Object.keys(tokenInfo).forEach((key) => {
     console.log(`${key}:`)
     console.log(tokenInfo[key])
@@ -157,12 +151,9 @@ const DeveloperScreen: FC<DeveloperScreenSettingsScreenProps> = ({ navigation })
         const val = tokenInfo[key]
         return (
           <Box key={key} mt={theme.dimensions.condensedMarginBetween}>
-            <TextArea
-              onPress={(): void => {
-                onCopy(val)
-              }}>
+            <TextArea>
               <TextView variant="MobileBodyBold">{key}</TextView>
-              <TextView>{val}</TextView>
+              <TextView selectable={true}>{val}</TextView>
             </TextArea>
           </Box>
         )
@@ -177,12 +168,9 @@ const DeveloperScreen: FC<DeveloperScreenSettingsScreenProps> = ({ navigation })
           ? Object.entries(userAuthorizedServices).map((key) => {
               return (
                 <Box key={key[0]} mt={theme.dimensions.condensedMarginBetween}>
-                  <TextArea
-                    onPress={(): void => {
-                      onCopy(key[1].toString())
-                    }}>
+                  <TextArea>
                     <TextView variant="MobileBodyBold">{key}</TextView>
-                    <TextView>{key[1].toString()}</TextView>
+                    <TextView selectable={true}>{key[1].toString()}</TextView>
                   </TextArea>
                 </Box>
               )
@@ -199,12 +187,9 @@ const DeveloperScreen: FC<DeveloperScreenSettingsScreenProps> = ({ navigation })
           const val = (envVars[key as keyof EnvVars] || '').toString()
           return (
             <Box key={key} mt={theme.dimensions.condensedMarginBetween}>
-              <TextArea
-                onPress={(): void => {
-                  onCopy(val)
-                }}>
+              <TextArea>
                 <TextView variant="MobileBodyBold">{key}</TextView>
-                <TextView>{val}</TextView>
+                <TextView selectable={true}>{val}</TextView>
               </TextArea>
             </Box>
           )
@@ -274,23 +259,17 @@ const DeveloperScreen: FC<DeveloperScreenSettingsScreenProps> = ({ navigation })
       </Box>
       <Box mb={theme.dimensions.contentMarginBottom}>
         <Box mt={theme.dimensions.condensedMarginBetween}>
-          <TextArea
-            onPress={(): void => {
-              onCopy(deviceToken || '')
-            }}>
+          <TextArea>
             <TextView variant="MobileBodyBold">Device Token</TextView>
-            <TextView>{deviceToken}</TextView>
+            <TextView selectable={true}>{deviceToken}</TextView>
           </TextArea>
         </Box>
       </Box>
       <Box mb={theme.dimensions.contentMarginBottom}>
         <Box mt={theme.dimensions.condensedMarginBetween}>
-          <TextArea
-            onPress={(): void => {
-              onCopy(deviceToken || '')
-            }}>
+          <TextArea>
             <TextView variant="MobileBodyBold">Endpoint SID</TextView>
-            <TextView>{deviceAppSid}</TextView>
+            <TextView selectable={true}>{deviceAppSid}</TextView>
           </TextArea>
         </Box>
       </Box>

--- a/VAMobile/yarn.lock
+++ b/VAMobile/yarn.lock
@@ -3165,11 +3165,6 @@
     prompts "^2.4.0"
     semver "^6.3.0"
 
-"@react-native-community/clipboard@^1.5.1":
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/@react-native-community/clipboard/-/clipboard-1.5.1.tgz#32abb3ea2eb91ee3f9c5fb1d32d5783253c9fabe"
-  integrity sha512-AHAmrkLEH5UtPaDiRqoULERHh3oNv7Dgs0bTC0hO5Z2GdNokAMPT5w8ci8aMcRemcwbtdHjxChgtjbeA38GBdA==
-
 "@react-native-community/eslint-config@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@react-native-community/eslint-config/-/eslint-config-3.0.1.tgz#c45968f1214139fe747a7aebdba06c4fa2a4d018"


### PR DESCRIPTION
## Description of Change
Removed @react-native-community/clipboard and updated it to use the textView selectable={true} prop in the Developer screen, native module actually wasn't needed and was already implemented with selectable

## Screenshots/Video
<img width="562" alt="Screenshot 2023-11-03 at 4 03 06 PM" src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/8db33e81-7dc8-42ca-ae10-8828ddcc0bed">


## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
 Create a native module for saving strings to the clipboard
 Replace instances of @react-native-community/clipboard with the native module
 Remove the @react-native-community/clipboard package from the repo

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
