### PR TITLE
remove auth maintenance window values

### DIFF
--- a/VAMobile/src/store/api/types/Errors.ts
+++ b/VAMobile/src/store/api/types/Errors.ts
@@ -30,9 +30,6 @@ export type ErrorMessage = {
 // exact service names received from maintenance windows api
 export type DowntimeFeatureType =
   | 'facility_locator'
-  | 'auth_dslogon'
-  | 'auth_idme'
-  | 'auth_mhv'
   | 'appeals'
   | 'military_service_history'
   | 'claims'
@@ -47,9 +44,6 @@ export type DowntimeFeatureType =
 
 export const DowntimeFeatureTypeConstants: {
   facilityLocator: DowntimeFeatureType
-  authDSLogon: DowntimeFeatureType
-  authIDMe: DowntimeFeatureType
-  authMHV: DowntimeFeatureType
   appeals: DowntimeFeatureType
   militaryServiceHistory: DowntimeFeatureType
   claims: DowntimeFeatureType
@@ -63,9 +57,6 @@ export const DowntimeFeatureTypeConstants: {
   rx: DowntimeFeatureType
 } = {
   facilityLocator: 'facility_locator',
-  authDSLogon: 'auth_dslogon',
-  authIDMe: 'auth_idme',
-  authMHV: 'auth_mhv',
   appeals: 'appeals',
   militaryServiceHistory: 'military_service_history',
   claims: 'claims',


### PR DESCRIPTION
## Description of Change
Removed unused 'auth_dslogon', 'auth_idme',  'auth_mhv' maintenance window references from the `Errors.ts` file in `/api/types`

## Screenshots/Video
Code only, no UI changes.

## Testing

- [ ] Tested on iOS <!-- simulator is fine -->
- [ ] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
References to the unused constants should be negative.

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [ ] PR is connected to issue(s)
- [ ] Tests are included to cover this change (when possible)
- [ ] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [ ] No secrets or API keys are checked in
- [ ] All imports are absolute (no relative imports)
- [ ] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
