### PR TITLE
feature/7256-Dylan-InPersonNonCPorCoommunityCareApptsCards

### DIFF
--- a/VAMobile/src/screens/HealthScreen/Appointments/PastAppointments/PastAppointments.test.tsx
+++ b/VAMobile/src/screens/HealthScreen/Appointments/PastAppointments/PastAppointments.test.tsx
@@ -161,7 +161,7 @@ context('PastAppointments', () => {
   it('initializes correctly', () => {
     expect(screen.getByText('Select a date range')).toBeTruthy()
     expect(screen.getAllByText('Past 3 months')).toBeTruthy()
-    expect(screen.getByTestId('Confirmed Saturday, February 6, 2021 11:53 AM PST VA Long Beach Healthcare System In-person')).toBeTruthy()
+    expect(screen.getByTestId('Confirmed Saturday, February 6, 2021 11:53 AM PST Type of care not noted Provider not noted At VA Long Beach Healthcare System')).toBeTruthy()
     expect(screen.getByText('2 to 2 of 2')).toBeTruthy()
     expect(screen.getByTestId('previous-page')).toBeTruthy()
     expect(screen.getByTestId('next-page')).toBeTruthy()
@@ -176,7 +176,7 @@ context('PastAppointments', () => {
 
   describe('when a appointment is clicked', () => {
     it('should call useRouteNavigation', () => {
-      fireEvent.press(screen.getByTestId('Confirmed Saturday, February 6, 2021 11:53 AM PST VA Long Beach Healthcare System In-person'))
+      fireEvent.press(screen.getByTestId('Confirmed Saturday, February 6, 2021 11:53 AM PST Type of care not noted Provider not noted At VA Long Beach Healthcare System'))
       expect(mockNavigationSpy).toHaveBeenCalledWith('PastAppointmentDetails', { appointmentID: '1' })
       expect(mockNavigateToSpy).toHaveBeenCalled()
     })

--- a/VAMobile/src/screens/HealthScreen/Appointments/UpcomingAppointments/UpcomingAppointments.test.tsx
+++ b/VAMobile/src/screens/HealthScreen/Appointments/UpcomingAppointments/UpcomingAppointments.test.tsx
@@ -143,7 +143,7 @@ context('UpcomingAppointments', () => {
 
   describe('on appointment press', () => {
     it('should call useRouteNavigation', () => {
-      fireEvent.press(screen.getByTestId('Confirmed Saturday, February 6, 2021 11:53 AM PST VA Long Beach Healthcare System In-person'))
+      fireEvent.press(screen.getByTestId('Confirmed Saturday, February 6, 2021 11:53 AM PST Type of care not noted Provider not noted At VA Long Beach Healthcare System'))
       expect(mockNavigationSpy).toHaveBeenCalledWith('UpcomingAppointmentDetails', { appointmentID: '1' })
       expect(navigateToSpy).toHaveBeenCalled()
     })

--- a/VAMobile/src/store/api/demo/mocks/appointments.json
+++ b/VAMobile/src/store/api/demo/mocks/appointments.json
@@ -971,7 +971,7 @@
             "minutesDuration": null,
             "phoneOnly": false,
             "startDateLocal": "{{now + 4 days}}",
-            "startDateUtc": "{{now + 4  days utc}}",
+            "startDateUtc": "{{now + 4 days utc}}",
             "status": "SUBMITTED",
             "statusDetail": null,
             "timeZone": "America/Denver",

--- a/VAMobile/src/store/api/demo/mocks/appointments.json
+++ b/VAMobile/src/store/api/demo/mocks/appointments.json
@@ -44,6 +44,87 @@
           }
         },
         {
+          "id": "8a48e8db6d70a38a016d72b3542400032",
+          "type": "appointment",
+          "attributes":
+          {
+            "appointmentType": "VA",
+            "cancelId": null,
+            "comment": null,
+            "healthcareProvider": null,
+            "healthcareService": null,
+            "location": null,
+            "minutesDuration": null,
+            "phoneOnly": false,
+            "startDateLocal": "{{now - 2 days}}",
+            "startDateUtc": "{{now - 2 days utc}}",
+            "status": "CANCELLED",
+            "statusDetail": "CANCELLED BY CLINIC",
+            "timeZone": "America/Denver",
+            "vetextId": null,
+            "reason": null,
+            "isCovidVaccine": null,
+            "isPending": true,
+            "proposedTimes": null,
+            "typeOfCare": null,
+            "patientPhoneNumber": "(666) 666-6666",
+            "patientEmail": "Vilasini.reddy@va.gov",
+            "bestTimeToCall": ["Morning"],
+            "friendlyLocationName": "DAYTSHR -Dayton VA Medical Center"
+          }
+        },
+        {
+          "id": "8a48e8db6d70a38a016d72b3542400031",
+          "type": "appointment",
+          "attributes":
+          {
+            "appointmentType": "VA",
+            "cancelId": null,
+            "comment": null,
+            "healthcareProvider": "John Smith",
+            "healthcareService": null,
+            "location":
+            {
+              "id": "442",
+              "name": "Cheyenne VA Medical Center",
+              "address":
+              {
+                "street": "2360 East Pershing Boulevard",
+                "city": "Cheyenne",
+                "state": "WY",
+                "zipCode": "82001-5356"
+              },
+              "lat": 41.148027,
+              "long": -104.7862575,
+              "phone":
+              {
+                "areaCode": "307",
+                "number": "778-7550",
+                "extension": null
+              },
+              "url": null,
+              "code": null
+            },
+            "minutesDuration": null,
+            "phoneOnly": false,
+            "startDateLocal": "{{now - 3 days}}",
+            "startDateUtc": "{{now - 3 days utc}}",
+            "status": "BOOKED",
+            "statusDetail": null,
+            "timeZone": "America/Denver",
+            "vetextId": null,
+            "reason": "New Issue",
+            "isCovidVaccine": null,
+            "isPending": false,
+            "proposedTimes": null,
+            "typeOfCare": "Primary Care",
+            "patientPhoneNumber": "(666) 666-6666",
+            "patientEmail": "Vilasini.reddy@va.gov",
+            "bestTimeToCall": ["Morning"],
+            "friendlyLocationName": "DAYTSHR -Dayton VA Medical Center"
+          }
+        },
+        {
           "type": "appointment",
           "id": "34",
           "attributes": {
@@ -772,6 +853,151 @@
             "isCovidVaccine": false,
             "serviceCategoryName": "COMPENSATION & PENSION",
             "typeOfCare": "Audiology and speech (including hearing aid support)"
+          }
+        },
+        {
+          "id": "8a48e8db6d70a38a016d72b35424000321",
+          "type": "appointment",
+          "attributes":
+          {
+            "appointmentType": "VA",
+            "cancelId": null,
+            "comment": null,
+            "healthcareProvider": null,
+            "healthcareService": null,
+            "location": null,
+            "minutesDuration": null,
+            "phoneOnly": false,
+            "startDateLocal": "{{now + 2 days}}",
+            "startDateUtc": "{{now + 2 days utc}}",
+            "status": "CANCELLED",
+            "statusDetail": "CANCELLED BY CLINIC",
+            "timeZone": "America/Denver",
+            "vetextId": null,
+            "reason": null,
+            "isCovidVaccine": null,
+            "isPending": true,
+            "proposedTimes": null,
+            "typeOfCare": null,
+            "patientPhoneNumber": "(666) 666-6666",
+            "patientEmail": "Vilasini.reddy@va.gov",
+            "bestTimeToCall": ["Morning"],
+            "friendlyLocationName": "DAYTSHR -Dayton VA Medical Center"
+          }
+        },
+        {
+          "id": "8a48e8db6d70a38a016d72b35424000311",
+          "type": "appointment",
+          "attributes":
+          {
+            "appointmentType": "VA",
+            "cancelId": null,
+            "comment": null,
+            "healthcareProvider": "John Smith",
+            "healthcareService": "Physical",
+            "location":
+            {
+              "id": "442",
+              "name": "Cheyenne VA Medical Center",
+              "address":
+              {
+                "street": "2360 East Pershing Boulevard",
+                "city": "Cheyenne",
+                "state": "WY",
+                "zipCode": "82001-5356"
+              },
+              "lat": 41.148027,
+              "long": -104.7862575,
+              "phone":
+              {
+                "areaCode": "307",
+                "number": "778-7550",
+                "extension": null
+              },
+              "url": null,
+              "code": null
+            },
+            "minutesDuration": null,
+            "phoneOnly": false,
+            "startDateLocal": "{{now + 3 days}}",
+            "startDateUtc": "{{now + 3 days utc}}",
+            "status": "BOOKED",
+            "statusDetail": null,
+            "timeZone": "America/Denver",
+            "vetextId": null,
+            "reason": "New Issue",
+            "isCovidVaccine": null,
+            "isPending": false,
+            "proposedTimes": null,
+            "typeOfCare": "Primary Care",
+            "patientPhoneNumber": "(666) 666-6666",
+            "patientEmail": "Vilasini.reddy@va.gov",
+            "bestTimeToCall": ["Morning"],
+            "friendlyLocationName": "DAYTSHR -Dayton VA Medical Center"
+          }
+        },
+        {
+          "id": "8a48e8db6d70a38a016d72b354240003",
+          "type": "appointment",
+          "attributes":
+          {
+            "appointmentType": "VA",
+            "cancelId": null,
+            "comment": null,
+            "healthcareProvider": "John Smith",
+            "healthcareService": "Physical",
+            "location":
+            {
+              "id": "442",
+              "name": "Cheyenne VA Medical Center",
+              "address":
+              {
+                "street": "2360 East Pershing Boulevard",
+                "city": "Cheyenne",
+                "state": "WY",
+                "zipCode": "82001-5356"
+              },
+              "lat": 41.148027,
+              "long": -104.7862575,
+              "phone":
+              {
+                "areaCode": "307",
+                "number": "778-7550",
+                "extension": null
+              },
+              "url": null,
+              "code": null
+            },
+            "minutesDuration": null,
+            "phoneOnly": false,
+            "startDateLocal": "{{now + 4 days}}",
+            "startDateUtc": "{{now + 4  days utc}}",
+            "status": "SUBMITTED",
+            "statusDetail": null,
+            "timeZone": "America/Denver",
+            "vetextId": null,
+            "reason": "New Issue",
+            "isCovidVaccine": null,
+            "isPending": true,
+            "proposedTimes":[
+              {
+                "date": "{{now + 4 days short}}",
+                "time": "PM"
+              },
+              {
+                "date": "{{now + 5 days short}}",
+                "time": "AM"
+              },
+              {
+                "date": "{{now + 6 days short}}",
+                "time": "AM"
+              }
+            ],
+            "typeOfCare": "Primary Care",
+            "patientPhoneNumber": "(666) 666-6666",
+            "patientEmail": "Vilasini.reddy@va.gov",
+            "bestTimeToCall": ["Morning"],
+            "friendlyLocationName": "DAYTSHR -Dayton VA Medical Center"
           }
         },
         {

--- a/VAMobile/src/translations/en/common.json
+++ b/VAMobile/src/translations/en/common.json
@@ -198,6 +198,7 @@
   "appointments": "Appointments",
   "appointments.appointment": "Appointment",
   "appointments.appointmentsStatusSomeUnavailable": " We can't load some of your VA appointments",
+  "appointments.atFacilityName": "At {{facilityName}}",
   "appointments.cancelAppointment": "Cancel appointment",
   "appointments.cancelRequest": "Cancel appointment request?",
   "appointments.cancelThisAppointment": "Cancel this appointment?",

--- a/VAMobile/src/utils/appointments.tsx
+++ b/VAMobile/src/utils/appointments.tsx
@@ -260,14 +260,19 @@ export const getTextLinesForAppointmentListItem = (appointment: AppointmentData,
     textLines.push(status)
   }
 
-  if (phoneOnly) {
+  if (phoneOnly || (appointmentType === AppointmentTypeConstants.VA && serviceCategoryName !== 'COMPENSATION & PENSION')) {
+    const facilityName = location.name
     textLines.push(
       { text: t('text.raw', { text: getFormattedDateWithWeekdayForTimeZone(startDateUtc, timeZone) }), variant: 'MobileBodyBold' },
       { text: t('text.raw', { text: getFormattedTimeForTimeZone(startDateUtc, timeZone) }), variant: 'MobileBodyBold', mb: condensedMarginBetween },
-      { text: t('text.raw', { text: typeOfCare ? typeOfCare : t('appointments.noTypeOfCare') }), variant: 'HelperText', mb: 5 },
-      { text: t('text.raw', { text: healthcareProvider ? healthcareProvider : t('appointments.noProvider') }), variant: 'HelperText', mb: 5 },
       {
-        text: t('text.raw', { text: getAppointmentTypeIconText(appointmentType, t, phoneOnly) }),
+        text: t('text.raw', { text: isCovidVaccine ? t('upcomingAppointments.covidVaccine') : typeOfCare || t('appointments.noTypeOfCare') }),
+        variant: 'HelperText',
+        mb: 5,
+      },
+      { text: t('text.raw', { text: healthcareProvider || t('appointments.noProvider') }), variant: 'HelperText', mb: 5 },
+      {
+        text: t('text.raw', { text: phoneOnly ? t('appointmentList.phoneOnly') : t('appointments.atFacilityName', { facilityName }) }),
         iconProps: getAppointmentTypeIcon(appointmentType, phoneOnly, theme),
         variant: 'HelperText',
       },

--- a/VAMobile/src/utils/appointments.tsx
+++ b/VAMobile/src/utils/appointments.tsx
@@ -261,7 +261,7 @@ export const getTextLinesForAppointmentListItem = (appointment: AppointmentData,
   }
 
   if (phoneOnly || (appointmentType === AppointmentTypeConstants.VA && serviceCategoryName !== 'COMPENSATION & PENSION')) {
-    const facilityName = location.name
+    const facilityName = location?.name || t('prescription.details.vaFacilityHeader')
     textLines.push(
       { text: t('text.raw', { text: getFormattedDateWithWeekdayForTimeZone(startDateUtc, timeZone) }), variant: 'MobileBodyBold' },
       { text: t('text.raw', { text: getFormattedTimeForTimeZone(startDateUtc, timeZone) }), variant: 'MobileBodyBold', mb: condensedMarginBetween },


### PR DESCRIPTION
## Description of Change
updated the card for in person VA appointments to match the new design that was previously updated for phone appts

this only covers in person VA appointments and covid appointments, it does not cover C&P or community care

## Screenshots/Video
<img width="562" alt="Screenshot 2023-11-30 at 9 19 02 AM" src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/267d34eb-b468-47c7-a0e2-754f03caf52e">
<img width="562" alt="Screenshot 2023-11-30 at 9 19 08 AM" src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/56a444b5-c1ed-427f-801c-a87f62d069ad">
<img width="562" alt="Screenshot 2023-11-30 at 9 19 27 AM" src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/e8fca16d-5de4-429c-8792-8233f756211b">
<img width="562" alt="Screenshot 2023-11-30 at 9 20 49 AM" src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/dc1a0650-b384-4723-9f9e-3c7f350fe9e9">


## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
Update Appointment Card for VA Appointments

 [Status] icon
 [Day/date/time] (bold)
 [Type of care]
 If type of care is not available, display: Type of care not noted
 [Provider name]
 If provider name is not available, display: Provider not noted
 Modality icon At [facility name]

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
