### PR TITLE
Bug/7255-Chika-AF-alert-should-be-under-VCL-banner

### DIFF
--- a/VAMobile/src/components/Templates/CategoryLanding.tsx
+++ b/VAMobile/src/components/Templates/CategoryLanding.tsx
@@ -99,15 +99,13 @@ export const CategoryLanding: FC<CategoryLandingProps> = ({ title, headerButton,
     <View style={fillStyle}>
       <StatusBar translucent barStyle={theme.mode === 'dark' ? 'light-content' : 'dark-content'} backgroundColor={theme.colors.background.main} />
       <HeaderBanner {...headerProps} />
-      <WaygateWrapper>
-        <VAScrollView testID={testID} scrollEventThrottle={title ? 1 : 0} onScroll={onScroll} {...scrollViewProps}>
-          <View onLayout={getTransitionHeaderHeight}>
-            <CrisisLineCta onPress={navigateTo('VeteransCrisisLine')} />
-            {title && !screenReaderEnabled ? <TextView {...subtitleProps}>{title}</TextView> : null}
-          </View>
-          {children}
-        </VAScrollView>
-      </WaygateWrapper>
+      <VAScrollView testID={testID} scrollEventThrottle={title ? 1 : 0} onScroll={onScroll} {...scrollViewProps}>
+        <View onLayout={getTransitionHeaderHeight}>
+          <CrisisLineCta onPress={navigateTo('VeteransCrisisLine')} />
+          {title && !screenReaderEnabled ? <TextView {...subtitleProps}>{title}</TextView> : null}
+        </View>
+        <WaygateWrapper>{children}</WaygateWrapper>
+      </VAScrollView>
     </View>
   )
 }

--- a/VAMobile/src/components/Templates/FullScreenSubtask.tsx
+++ b/VAMobile/src/components/Templates/FullScreenSubtask.tsx
@@ -173,29 +173,27 @@ export const FullScreenSubtask: FC<FullScreenSubtaskProps> = ({
   return (
     <View {...fillStyle}>
       <HeaderBanner {...headerProps} />
-      <WaygateWrapper>
-        <VAScrollView scrollViewRef={scrollViewRef} testID={testID}>
-          {showCrisisLineCta && <CrisisLineCta onPress={navigateTo('VeteransCrisisLine')} />}
-          {title && (
-            <Box mt={titleMarginTop} mb={theme.dimensions.buttonPadding} mx={theme.dimensions.gutter}>
-              <TextView {...titleTextProps}>{title}</TextView>
-            </Box>
-          )}
-          {children}
-        </VAScrollView>
-        {primaryContentButtonText && onPrimaryContentButtonPress && (
-          <Box display="flex" flexDirection="row" mt={theme.dimensions.condensedMarginBetween} mb={theme.dimensions.contentMarginBottom} alignItems={'center'}>
-            {secondaryContentButtonText && onSecondaryContentButtonPress && (
-              <Box ml={theme.dimensions.gutter} flex={1}>
-                <VAButton onPress={onSecondaryContentButtonPress} label={secondaryContentButtonText} buttonType={ButtonTypesConstants.buttonSecondary} />
-              </Box>
-            )}
-            <Box ml={secondaryContentButtonText && onSecondaryContentButtonPress ? theme.dimensions.buttonPadding : theme.dimensions.gutter} mr={theme.dimensions.gutter} flex={1}>
-              <VAButton onPress={onPrimaryContentButtonPress} label={primaryContentButtonText} buttonType={ButtonTypesConstants.buttonPrimary} testID={primaryButtonTestID} />
-            </Box>
+      <VAScrollView scrollViewRef={scrollViewRef} testID={testID}>
+        {showCrisisLineCta && <CrisisLineCta onPress={navigateTo('VeteransCrisisLine')} />}
+        {title && (
+          <Box mt={titleMarginTop} mb={theme.dimensions.buttonPadding} mx={theme.dimensions.gutter}>
+            <TextView {...titleTextProps}>{title}</TextView>
           </Box>
         )}
-      </WaygateWrapper>
+        <WaygateWrapper>{children}</WaygateWrapper>
+      </VAScrollView>
+      {primaryContentButtonText && onPrimaryContentButtonPress && (
+        <Box display="flex" flexDirection="row" mt={theme.dimensions.condensedMarginBetween} mb={theme.dimensions.contentMarginBottom} alignItems={'center'}>
+          {secondaryContentButtonText && onSecondaryContentButtonPress && (
+            <Box ml={theme.dimensions.gutter} flex={1}>
+              <VAButton onPress={onSecondaryContentButtonPress} label={secondaryContentButtonText} buttonType={ButtonTypesConstants.buttonSecondary} />
+            </Box>
+          )}
+          <Box ml={secondaryContentButtonText && onSecondaryContentButtonPress ? theme.dimensions.buttonPadding : theme.dimensions.gutter} mr={theme.dimensions.gutter} flex={1}>
+            <VAButton onPress={onPrimaryContentButtonPress} label={primaryContentButtonText} buttonType={ButtonTypesConstants.buttonPrimary} testID={primaryButtonTestID} />
+          </Box>
+        </Box>
+      )}
     </View>
   )
 }


### PR DESCRIPTION
## Description of Change
- Moved AF alert to always sit below the VCL banner.

## Screenshots/Video
<!-- Add screenshots or video as needed. Before/after if changes are to be compared by reviewers.
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Toggle: <details><summary></summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>
-->
Before/after:

<img src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/53785439/7bbd11e9-8fa1-43d7-8a60-3f6dd2400626" width="49%" />&nbsp;&nbsp;<img src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/53785439/cb60c311-eab4-463e-9e1b-06c241a87339" width="49%" />

## Testing
- [ ] Tested on iOS <!-- simulator is fine -->
- [ ] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
- Verify AF alert is below VeteranCrisisLine Banner

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [ ] PR is connected to issue(s)
- [ ] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
