### PR TITLE
feature/6983-theo-AFAnalytics

### DIFF
--- a/VAMobile/src/components/WaygateWrapper.tsx
+++ b/VAMobile/src/components/WaygateWrapper.tsx
@@ -63,7 +63,7 @@ export const WaygateWrapper: FC<WaygateWrapperProps> = ({ children, waygateName,
       const afStatus = waygate.type === 'DenyContent' ? 'open' : 'closed'
       logAnalyticsEvent(Events.vama_af_shown(afStatus, screenName))
     }
-  }, [])
+  }, [bypassAlertBox, screenName, showAlertBox, waygate.type])
 
   if (showAlertBox) {
     const showScreenContent = waygate.type === 'AllowFunction' || waygateName === 'WG_Login'

--- a/VAMobile/src/components/WaygateWrapper.tsx
+++ b/VAMobile/src/components/WaygateWrapper.tsx
@@ -9,7 +9,6 @@ import { a11yLabelID } from 'utils/a11yLabel'
 import { displayedTextPhoneNumber } from 'utils/formattingUtils'
 import { logAnalyticsEvent } from 'utils/analytics'
 import { openAppStore } from 'utils/homeScreenAlerts'
-import { requestStorePopup } from 'utils/rnInAppUpdate'
 import { useTheme } from 'utils/hooks'
 import { useTranslation } from 'react-i18next'
 

--- a/VAMobile/src/components/WaygateWrapper.tsx
+++ b/VAMobile/src/components/WaygateWrapper.tsx
@@ -14,16 +14,14 @@ import { useTheme } from 'utils/hooks'
 import { useTranslation } from 'react-i18next'
 
 export type WaygateWrapperProps = {
-  /** the waygate name to check for */
-  waygateName?: WaygateToggleType
   /** flag for template footer buttons to not double up alertbox display */
   bypassAlertBox?: boolean
 }
 
-export const WaygateWrapper: FC<WaygateWrapperProps> = ({ children, waygateName, bypassAlertBox }) => {
+export const WaygateWrapper: FC<WaygateWrapperProps> = ({ children, bypassAlertBox }) => {
   const theme = useTheme()
   const { t } = useTranslation(NAMESPACE.COMMON)
-  const screenName = useNavigationState((state) => state.routes[state.routes.length - 1]?.name)
+  const waygateScreen = 'WG_' + useNavigationState((state) => state.routes[state.routes.length - 1]?.name)
 
   const waygateTypeCheck = (waygateType: string | undefined) => {
     if (waygateType === 'DenyContent' || waygateType === 'AllowFunction') {
@@ -37,9 +35,6 @@ export const WaygateWrapper: FC<WaygateWrapperProps> = ({ children, waygateName,
     const onUpdateButtonPress = async () => {
       logAnalyticsEvent(Events.vama_af_updated())
       openAppStore()
-
-      const isUpdated = await requestStorePopup()
-      isUpdated && logAnalyticsEvent(Events.vama_af_updated_success(screenName))
     }
 
     return (
@@ -54,19 +49,18 @@ export const WaygateWrapper: FC<WaygateWrapperProps> = ({ children, waygateName,
     )
   }
 
-  const waygateToggle = waygateName || `WG_${screenName}`
-  const waygate = waygateEnabled(waygateToggle as WaygateToggleType)
+  const waygate = waygateEnabled(waygateScreen as WaygateToggleType)
   const showAlertBox = waygate.enabled === false && waygateTypeCheck(waygate.type) && (waygate.errorMsgTitle || waygate.errorMsgBody)
 
   useEffect(() => {
     if (showAlertBox && !bypassAlertBox) {
       const afStatus = waygate.appUpdateButton ? 'closed' : 'open'
-      logAnalyticsEvent(Events.vama_af_shown(afStatus, screenName))
+      logAnalyticsEvent(Events.vama_af_shown(afStatus, waygateScreen))
     }
-  }, [bypassAlertBox, screenName, showAlertBox, waygate.appUpdateButton])
+  }, [bypassAlertBox, waygateScreen, showAlertBox, waygate.appUpdateButton])
 
   if (showAlertBox) {
-    const showScreenContent = waygate.type === 'AllowFunction' || waygateName === 'WG_Login'
+    const showScreenContent = waygate.type === 'AllowFunction' || waygateScreen === 'WG_Login'
     return (
       <>
         {!bypassAlertBox && waygateAlertBox(waygate)}

--- a/VAMobile/src/components/WaygateWrapper.tsx
+++ b/VAMobile/src/components/WaygateWrapper.tsx
@@ -22,8 +22,8 @@ export type WaygateWrapperProps = {
 export const WaygateWrapper: FC<WaygateWrapperProps> = ({ children, waygateName, bypassAlertBox }) => {
   const theme = useTheme()
   const waygateStateScreen = 'WG_' + useNavigationState((state) => state.routes[state.routes.length - 1]?.name)
-  const { t } = useTranslation(NAMESPACE.COMMON)
   const waygateScreen = waygateName || waygateStateScreen
+  const { t } = useTranslation(NAMESPACE.COMMON)
 
   const waygateTypeCheck = (waygateType: string | undefined) => {
     if (waygateType === 'DenyContent' || waygateType === 'AllowFunction') {

--- a/VAMobile/src/components/WaygateWrapper.tsx
+++ b/VAMobile/src/components/WaygateWrapper.tsx
@@ -63,7 +63,7 @@ export const WaygateWrapper: FC<WaygateWrapperProps> = ({ children, waygateName,
       const afStatus = waygate.appUpdateButton ? 'closed' : 'open'
       logAnalyticsEvent(Events.vama_af_shown(afStatus, screenName))
     }
-  }, [bypassAlertBox, screenName, showAlertBox, waygate.type])
+  }, [bypassAlertBox, screenName, showAlertBox,waygate.appUpdateButton])
 
   if (showAlertBox) {
     const showScreenContent = waygate.type === 'AllowFunction' || waygateName === 'WG_Login'

--- a/VAMobile/src/components/WaygateWrapper.tsx
+++ b/VAMobile/src/components/WaygateWrapper.tsx
@@ -63,7 +63,7 @@ export const WaygateWrapper: FC<WaygateWrapperProps> = ({ children, waygateName,
       const afStatus = waygate.appUpdateButton ? 'closed' : 'open'
       logAnalyticsEvent(Events.vama_af_shown(afStatus, screenName))
     }
-  }, [bypassAlertBox, screenName, showAlertBox,waygate.appUpdateButton])
+  }, [bypassAlertBox, screenName, showAlertBox, waygate.appUpdateButton])
 
   if (showAlertBox) {
     const showScreenContent = waygate.type === 'AllowFunction' || waygateName === 'WG_Login'

--- a/VAMobile/src/components/WaygateWrapper.tsx
+++ b/VAMobile/src/components/WaygateWrapper.tsx
@@ -13,11 +13,13 @@ import { useTheme } from 'utils/hooks'
 import { useTranslation } from 'react-i18next'
 
 export type WaygateWrapperProps = {
+  /** the waygate name to check for */
+  waygateName?: WaygateToggleType
   /** flag for template footer buttons to not double up alertbox display */
   bypassAlertBox?: boolean
 }
 
-export const WaygateWrapper: FC<WaygateWrapperProps> = ({ children, bypassAlertBox }) => {
+export const WaygateWrapper: FC<WaygateWrapperProps> = ({ children, waygateName, bypassAlertBox }) => {
   const theme = useTheme()
   const { t } = useTranslation(NAMESPACE.COMMON)
   const waygateScreen = 'WG_' + useNavigationState((state) => state.routes[state.routes.length - 1]?.name)
@@ -48,7 +50,8 @@ export const WaygateWrapper: FC<WaygateWrapperProps> = ({ children, bypassAlertB
     )
   }
 
-  const waygate = waygateEnabled(waygateScreen as WaygateToggleType)
+  const waygateToggle = waygateName || waygateScreen
+  const waygate = waygateEnabled(waygateToggle as WaygateToggleType)
   const showAlertBox = waygate.enabled === false && waygateTypeCheck(waygate.type) && (waygate.errorMsgTitle || waygate.errorMsgBody)
 
   useEffect(() => {
@@ -59,7 +62,7 @@ export const WaygateWrapper: FC<WaygateWrapperProps> = ({ children, bypassAlertB
   }, [bypassAlertBox, waygateScreen, showAlertBox, waygate.appUpdateButton])
 
   if (showAlertBox) {
-    const showScreenContent = waygate.type === 'AllowFunction' || waygateScreen === 'WG_Login'
+    const showScreenContent = waygate.type === 'AllowFunction' || waygateName === 'WG_Login'
     return (
       <>
         {!bypassAlertBox && waygateAlertBox(waygate)}

--- a/VAMobile/src/components/WaygateWrapper.tsx
+++ b/VAMobile/src/components/WaygateWrapper.tsx
@@ -60,7 +60,7 @@ export const WaygateWrapper: FC<WaygateWrapperProps> = ({ children, waygateName,
 
   useEffect(() => {
     if (showAlertBox && !bypassAlertBox) {
-      const afStatus = waygate.type === 'DenyContent' ? 'open' : 'closed'
+      const afStatus = waygate.appUpdateButton ? 'closed' : 'open'
       logAnalyticsEvent(Events.vama_af_shown(afStatus, screenName))
     }
   }, [bypassAlertBox, screenName, showAlertBox, waygate.type])

--- a/VAMobile/src/components/WaygateWrapper.tsx
+++ b/VAMobile/src/components/WaygateWrapper.tsx
@@ -22,7 +22,7 @@ export type WaygateWrapperProps = {
 export const WaygateWrapper: FC<WaygateWrapperProps> = ({ children, waygateName, bypassAlertBox }) => {
   const theme = useTheme()
   const { t } = useTranslation(NAMESPACE.COMMON)
-  const waygateScreen = 'WG_' + useNavigationState((state) => state.routes[state.routes.length - 1]?.name)
+  const waygateScreen = waygateName || 'WG_' + useNavigationState((state) => state.routes[state.routes.length - 1]?.name)
 
   const waygateTypeCheck = (waygateType: string | undefined) => {
     if (waygateType === 'DenyContent' || waygateType === 'AllowFunction') {
@@ -50,8 +50,7 @@ export const WaygateWrapper: FC<WaygateWrapperProps> = ({ children, waygateName,
     )
   }
 
-  const waygateToggle = waygateName || waygateScreen
-  const waygate = waygateEnabled(waygateToggle as WaygateToggleType)
+  const waygate = waygateEnabled(waygateScreen as WaygateToggleType)
   const showAlertBox = waygate.enabled === false && waygateTypeCheck(waygate.type) && (waygate.errorMsgTitle || waygate.errorMsgBody)
 
   useEffect(() => {

--- a/VAMobile/src/components/WaygateWrapper.tsx
+++ b/VAMobile/src/components/WaygateWrapper.tsx
@@ -21,8 +21,9 @@ export type WaygateWrapperProps = {
 
 export const WaygateWrapper: FC<WaygateWrapperProps> = ({ children, waygateName, bypassAlertBox }) => {
   const theme = useTheme()
+  const waygateStateScreen = 'WG_' + useNavigationState((state) => state.routes[state.routes.length - 1]?.name)
   const { t } = useTranslation(NAMESPACE.COMMON)
-  const waygateScreen = waygateName || 'WG_' + useNavigationState((state) => state.routes[state.routes.length - 1]?.name)
+  const waygateScreen = waygateName || waygateStateScreen
 
   const waygateTypeCheck = (waygateType: string | undefined) => {
     if (waygateType === 'DenyContent' || waygateType === 'AllowFunction') {

--- a/VAMobile/src/constants/analytics.ts
+++ b/VAMobile/src/constants/analytics.ts
@@ -15,6 +15,28 @@ export const Events = {
       },
     }
   },
+  vama_af_shown: (af_status: string, firebase_screen: string): Event => {
+    return {
+      name: 'vama_af_shown',
+      params: {
+        af_status,
+        firebase_screen,
+      },
+    }
+  },
+  vama_af_updated: (): Event => {
+    return {
+      name: 'vama_af_updated',
+    }
+  },
+  vama_af_updated_success: (firebase_screen: string): Event => {
+    return {
+      name: 'vama_af_updated_success',
+      params: {
+        firebase_screen,
+      },
+    }
+  },
   vama_appt_cancel: (
     isPendingAppointment: boolean,
     apt_id: string | undefined,

--- a/VAMobile/src/constants/analytics.ts
+++ b/VAMobile/src/constants/analytics.ts
@@ -29,14 +29,6 @@ export const Events = {
       name: 'vama_af_updated',
     }
   },
-  vama_af_updated_success: (firebase_screen: string): Event => {
-    return {
-      name: 'vama_af_updated_success',
-      params: {
-        firebase_screen,
-      },
-    }
-  },
   vama_appt_cancel: (
     isPendingAppointment: boolean,
     apt_id: string | undefined,


### PR DESCRIPTION
<!-- NOTE: Please include the related issue number in the PR title, otherwise the changes won't be merged 
into the `staging` branch upon ticket completion. E.g. '[Issue type]/[Issue #]-[Your name]-[Summary of issue]',
where Issue type = bug, feature, spike, CU (code upkeep), etc. -->

## Description of Change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, 
need to know about this PR in order to understand why this PR was created? This could include dependencies 
introduced, changes in behavior, pointers to more detailed documentation. The description should be more 
than a link to an issue.  -->
Adds analytics for availability framework.

## Screenshots/Video
<!-- Add screenshots or video as needed. Before/after if changes are to be compared by reviewers.
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Toggle: <details><summary></summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>
-->
N/A

## Testing
<!-- What testing was done to verify the changes (local/unit)? What testing remains? Note edge cases, or special
situations that could not be tested during development. -->
Tested logic for event triggers locally.

- [ ] Tested on iOS <!-- simulator is fine -->
- [ ] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
<!-- What should reviewers look for? Copy/paste Acceptance Criteria from ticket -->
- [ ] `vama_af_shown` capture any time an availability framework message is displayed to a user. Include parameter for:
  - [ ] `af_status` capture if the message is currently stating that there is an error that we're working on (`open`) or if the error has been resolved and the message is now displaying an update button to users (`closed`)
  - [ ] `firebase_screen` should be automatically collected but make sure that is recorded with this event in case we are ever in a situation were AF is being used on two different screens in the app at the same time.
  
 - [ ] `vama_af_updated` capture if a user clicks to update the app from the button in the availability framework message
~~- [ ] `vama_af_updated_success` capture if the app version was successfully updated~~
  ~~- [ ] `firebase_screen` should be automatically collected but make sure that is recorded with this event in case we are ever in a situation were AF is being used on two different screens in the app at the same time~~

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [ ] PR is connected to issue(s)
- [ ] Tests are included to cover this change (when possible)
- [ ] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [ ] No secrets or API keys are checked in
- [ ] All imports are absolute (no relative imports)
- [ ] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
