### PR TITLE
bug/6619-Liz-select-list-header-font-size

### DIFF
--- a/VAMobile/src/components/SelectionList/SelectionList.tsx
+++ b/VAMobile/src/components/SelectionList/SelectionList.tsx
@@ -131,12 +131,12 @@ const SelectionList: FC<SelectionListProps> = ({ items, onSelectionChange }) => 
   return (
     <Box>
       <Box {...headerWrapperProps}>
-        <TextView variant={'HelperText'} accessibilityLabel={t('selectedOutOfTotal.a11yLabel', selectedOutOfTotal)}>
+        <TextView variant={'MobileBody'} accessibilityLabel={t('selectedOutOfTotal.a11yLabel', selectedOutOfTotal)}>
           {t('selectedOutOfTotal', selectedOutOfTotal)}
         </TextView>
         <Pressable {...pressableProps}>
           <Box display={'flex'} flexDirection={'row'} justifyContent={'space-between'} alignItems={'center'}>
-            <TextView variant={'HelperText'}>{t('select.all')}</TextView>
+            <TextView variant={'MobileBody'}>{t('select.all')}</TextView>
             {getSelectAllIcon()}
           </Box>
         </Pressable>


### PR DESCRIPTION
## Description of Change
Updated the font variant in the SlectionList header from `HelperText` to `MobileBody`.

## Screenshots/Video

Before/after: 

<img src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/72234279/4fddc201-cee1-49f3-8444-e9d282e8d45a" width="49%" />&nbsp;&nbsp;<img src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/72234279/626b6c78-cbef-4fc5-bea7-1c2112ed2b69" width="49%" />


## Testing
- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
<!-- What should reviewers look for? Copy/paste Acceptance Criteria from ticket -->
The text for the "x/x selected" and "select all" font should be larger than the helper text on the screen.

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [ ] PR is connected to issue(s)
- [ ] Tests are included to cover this change (when possible)
- [ ] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [ ] No secrets or API keys are checked in
- [ ] All imports are absolute (no relative imports)
- [ ] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
