### PR TITLE
done

### DIFF
--- a/.github/workflows/assign_qa_to_issue.yml
+++ b/.github/workflows/assign_qa_to_issue.yml
@@ -1,0 +1,37 @@
+#
+# Checks if health/global/design-system label is applied and then assigns the correct QA team member to that ticket
+#
+
+name: 'assign qa to issue'
+
+on:
+  issues:
+    types:
+      - labeled
+
+jobs:
+  run_on_labeled:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: if_health
+        if: github.event.label.name == 'health'
+        uses: actions-ecosystem/action-add-assignees@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          assignees: "DJUltraTom"
+
+      - name: if_global
+        if: github.event.label.name == 'global'
+        uses: actions-ecosystem/action-add-assignees@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          assignees: "TKDickson"
+
+      - name: if_design-system
+        if: github.event.label.name == 'design-system'
+        uses: actions-ecosystem/action-add-assignees@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          assignees: "rbontrager"


### PR DESCRIPTION
## Description of Change
When health/global/design-systems label is applied to an issue it automatically assigns the corresponding QA team member to it

## Screenshots/Video
N/A

## Testing
N/A

## Reviewer Validations
GitHub/ZenHub automation - When Health/Global/Platform team label is applied it auto assigns the corresponding QA team member to the zenhub issue

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
