### PR TITLE
bug/Dylan-7679-FixIOSLinkifyMessages2

### DIFF
--- a/VAMobile/src/utils/secureMessaging.tsx
+++ b/VAMobile/src/utils/secureMessaging.tsx
@@ -457,9 +457,7 @@ export const getLinkifiedText = (body: string, t: TFunction, launchExternalLink:
             accessible={true}
             accessibilityLabel={getNumberAccessibilityLabelFromString(previousText + text + nextText)}
             accessibilityHint={t('openInPhoneMessaging.a11yHint')}>
-            <TextView selectable={true} variant="MobileBodyLink">
-              {previousText + ' ' + text + ' ' + nextText}
-            </TextView>
+            <TextView variant="MobileBodyLink">{previousText + ' ' + text + ' ' + nextText}</TextView>
           </TouchableWithoutFeedback>,
         )
         textReconstructedBody.push(<TextView variant="MobileBody"> </TextView>)
@@ -484,9 +482,7 @@ export const getLinkifiedText = (body: string, t: TFunction, launchExternalLink:
           accessible={true}
           accessibilityLabel={text}
           accessibilityHint={t('openInEmailMessaging.a11yHint')}>
-          <TextView selectable={true} variant="MobileBodyLink">
-            {text}
-          </TextView>
+          <TextView variant="MobileBodyLink">{text}</TextView>
         </TouchableWithoutFeedback>,
       )
       textReconstructedBody.push(<TextView variant="MobileBody"> </TextView>)
@@ -501,9 +497,7 @@ export const getLinkifiedText = (body: string, t: TFunction, launchExternalLink:
           accessible={true}
           accessibilityLabel={text}
           accessibilityHint={t('openInEmailMessaging.a11yHint')}>
-          <TextView selectable={true} variant="MobileBodyLink">
-            {text}
-          </TextView>
+          <TextView variant="MobileBodyLink">{text}</TextView>
         </TouchableWithoutFeedback>,
       )
       textReconstructedBody.push(<TextView variant="MobileBody"> </TextView>)
@@ -518,9 +512,7 @@ export const getLinkifiedText = (body: string, t: TFunction, launchExternalLink:
           accessible={true}
           accessibilityLabel={getNumberAccessibilityLabelFromString(getNumbersFromString(text))}
           accessibilityHint={t('openInPhoneMessaging.a11yHint')}>
-          <TextView selectable={true} variant="MobileBodyLink">
-            {text}
-          </TextView>
+          <TextView variant="MobileBodyLink">{text}</TextView>
         </TouchableWithoutFeedback>,
       )
       textReconstructedBody.push(<TextView variant="MobileBody"> </TextView>)
@@ -536,9 +528,7 @@ export const getLinkifiedText = (body: string, t: TFunction, launchExternalLink:
           accessible={true}
           accessibilityLabel={text}
           accessibilityHint={t('openInBrowser.a11yHint')}>
-          <TextView selectable={true} variant="MobileBodyLink">
-            {text}
-          </TextView>
+          <TextView variant="MobileBodyLink">{text}</TextView>
         </TouchableWithoutFeedback>,
       )
       textReconstructedBody.push(<TextView variant="MobileBody"> </TextView>)
@@ -553,23 +543,19 @@ export const getLinkifiedText = (body: string, t: TFunction, launchExternalLink:
           accessible={true}
           accessibilityLabel={text}
           accessibilityHint={t('openInBrowser.a11yHint')}>
-          <TextView selectable={true} variant="MobileBodyLink">
-            {text}
-          </TextView>
+          <TextView variant="MobileBodyLink">{text}</TextView>
         </TouchableWithoutFeedback>,
       )
       textReconstructedBody.push(<TextView variant="MobileBody"> </TextView>)
     } else {
-      textReconstructedBody.push(
-        <TextView selectable={true} variant="MobileBody">
-          {text + ' '}
-        </TextView>,
-      )
+      textReconstructedBody.push(<TextView variant="MobileBody">{text + ' '}</TextView>)
     }
   })
   return (
     <Box>
-      <TextView paragraphSpacing={true}>{textReconstructedBody}</TextView>
+      <TextView selectable={true} paragraphSpacing={true}>
+        {textReconstructedBody}
+      </TextView>
     </Box>
   )
 }


### PR DESCRIPTION
## Description of Change
Original attempt at fixing accessiblity issues for the linkified text actually broke the functionality on iOS and wasn't caught. This PR reverts the attempted fix so that it functions properly while we still come up with a possible fix for accessiblity.

## Screenshots/Video
N/A

## Testing
Yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
Clicking on links should work on iOS

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
