### PR TITLE
feature/7309-Dylan-ButtonBenefitsUpdate

### DIFF
--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/AskForClaimDecision/AskForClaimDecision.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/AskForClaimDecision/AskForClaimDecision.tsx
@@ -1,23 +1,11 @@
+import { Button } from '@department-of-veterans-affairs/mobile-component-library'
 import { StackScreenProps } from '@react-navigation/stack/lib/typescript/src/types'
 import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
 import React, { FC, useEffect, useState } from 'react'
 
 import { BenefitsStackParamList } from 'screens/BenefitsScreen/BenefitsStackScreens'
-import {
-  Box,
-  ButtonTypesConstants,
-  ErrorComponent,
-  FieldType,
-  FormFieldType,
-  FormWrapper,
-  FullScreenSubtask,
-  LoadingComponent,
-  TextArea,
-  TextView,
-  VABulletList,
-  VAButton,
-} from 'components'
+import { Box, ErrorComponent, FieldType, FormFieldType, FormWrapper, FullScreenSubtask, LoadingComponent, TextArea, TextView, VABulletList } from 'components'
 import { ClaimTypeConstants } from 'screens/BenefitsScreen/ClaimsScreen/ClaimsAndAppealsListView/ClaimsAndAppealsListView'
 import { ClaimsAndAppealsState, submitClaimDecision } from 'store/slices'
 import { Events } from 'constants/analytics'
@@ -149,12 +137,7 @@ const AskForClaimDecision: FC<AskForClaimDecisionProps> = ({ navigation, route }
           <Box my={standardMarginBetween}>
             <FormWrapper fieldsList={formFieldsList} onSave={onRequestEvaluation} setOnSaveClicked={setOnSaveClicked} onSaveClicked={onSaveClicked} />
           </Box>
-          <VAButton
-            onPress={(): void => setOnSaveClicked(true)}
-            label={t('askForClaimDecision.submit')}
-            testID={t('askForClaimDecision.submit')}
-            buttonType={ButtonTypesConstants.buttonPrimary}
-          />
+          <Button onPress={(): void => setOnSaveClicked(true)} label={t('askForClaimDecision.submit')} testID={t('askForClaimDecision.submit')} />
         </Box>
       </Box>
     </FullScreenSubtask>

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/FileRequest.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/FileRequest.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@department-of-veterans-affairs/mobile-component-library'
 import { StackScreenProps } from '@react-navigation/stack/lib/typescript/src/types'
 import { map } from 'underscore'
 import { useSelector } from 'react-redux'
@@ -5,7 +6,7 @@ import { useTranslation } from 'react-i18next'
 import React, { FC } from 'react'
 
 import { BenefitsStackParamList } from 'screens/BenefitsScreen/BenefitsStackScreens'
-import { Box, ButtonTypesConstants, ChildTemplate, ErrorComponent, SimpleList, SimpleListItemObj, TextArea, TextView, VAButton } from 'components'
+import { Box, ChildTemplate, ErrorComponent, SimpleList, SimpleListItemObj, TextArea, TextView } from 'components'
 import { ClaimEventData } from 'store/api'
 import { ClaimsAndAppealsState } from 'store/slices/claimsAndAppealsSlice'
 import { Events } from 'constants/analytics'
@@ -113,11 +114,10 @@ const FileRequest: FC<FileRequestProps> = ({ navigation, route }) => {
               <TextView variant="MobileBody" paragraphSpacing={true}>
                 {t('fileRequest.askForYourClaimEvaluationBody')}
               </TextView>
-              <VAButton
+              <Button
                 onPress={viewEvaluationDetailsPress}
                 label={t('fileRequest.viewEvaluationDetails')}
                 testID={t('fileRequest.viewEvaluationDetails')}
-                buttonType={ButtonTypesConstants.buttonPrimary}
                 a11yHint={t('fileRequest.viewEvaluationDetails')}
               />
             </TextArea>

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/FileRequestDetails/FileRequestDetails.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/FileRequestDetails/FileRequestDetails.tsx
@@ -1,10 +1,11 @@
+import { Button, ButtonVariants } from '@department-of-veterans-affairs/mobile-component-library'
 import { StackScreenProps } from '@react-navigation/stack/lib/typescript/src/types'
 import { map } from 'underscore'
 import { useTranslation } from 'react-i18next'
 import React, { FC } from 'react'
 
 import { BenefitsStackParamList } from 'screens/BenefitsScreen/BenefitsStackScreens'
-import { Box, BoxProps, ButtonTypesConstants, ChildTemplate, TextArea, TextView, VAButton } from 'components'
+import { Box, BoxProps, ChildTemplate, TextArea, TextView } from 'components'
 import { Events } from 'constants/analytics'
 import { NAMESPACE } from 'constants/namespaces'
 import { formatDateMMMMDDYYYY } from 'utils/formattingUtils'
@@ -113,9 +114,9 @@ const FileRequestDetails: FC<FileRequestDetailsProps> = ({ navigation, route }) 
       {!hasUploaded && (
         <Box {...boxProps}>
           <Box mt={standardMarginBetween} mx={gutter} mb={contentMarginBottom}>
-            <VAButton onPress={onFilePress} label={t('fileUpload.selectAFile')} testID={t('fileUpload.selectAFile')} buttonType={ButtonTypesConstants.buttonSecondary} />
+            <Button onPress={onFilePress} label={t('fileUpload.selectAFile')} testID={t('fileUpload.selectAFile')} buttonType={ButtonVariants.Secondary} />
             <Box mt={theme.dimensions.condensedMarginBetween}>
-              <VAButton onPress={onPhotoPress} label={t('fileUpload.takePhotos')} testID={t('fileUpload.takePhotos')} buttonType={ButtonTypesConstants.buttonSecondary} />
+              <Button onPress={onPhotoPress} label={t('fileUpload.takePhotos')} testID={t('fileUpload.takePhotos')} buttonType={ButtonVariants.Secondary} />
             </Box>
           </Box>
         </Box>

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/SelectFile/SelectFile.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/SelectFile/SelectFile.tsx
@@ -1,10 +1,11 @@
+import { Button } from '@department-of-veterans-affairs/mobile-component-library'
 import { ScrollView } from 'react-native'
 import { StackScreenProps } from '@react-navigation/stack/lib/typescript/src/types'
 import { useTranslation } from 'react-i18next'
 import DocumentPicker from 'react-native-document-picker'
 import React, { FC, useRef, useState } from 'react'
 
-import { AlertBox, Box, ButtonTypesConstants, TextArea, TextView, VAButton } from 'components'
+import { AlertBox, Box, TextArea, TextView } from 'components'
 import { BenefitsStackParamList, DocumentPickerResponse } from 'screens/BenefitsScreen/BenefitsStackScreens'
 import { Events } from 'constants/analytics'
 import { MAX_TOTAL_FILE_SIZE_IN_BYTES, isValidFileType } from 'utils/claims'
@@ -135,7 +136,7 @@ const SelectFile: FC<SelectFilesProps> = ({ navigation, route }) => {
           <TextView variant="MobileBody">{t('fileUpload.acceptedFileTypeOptions')}</TextView>
         </TextArea>
         <Box mt={theme.dimensions.standardMarginBetween} mx={theme.dimensions.gutter}>
-          <VAButton onPress={onSelectFile} label={t('fileUpload.selectAFile')} testID={buttonTestId} buttonType={ButtonTypesConstants.buttonPrimary} />
+          <Button onPress={onSelectFile} label={t('fileUpload.selectAFile')} testID={buttonTestId} />
         </Box>
       </Box>
     </FullScreenSubtask>

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/SelectFile/UploadFile/UploadFile.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/SelectFile/UploadFile/UploadFile.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@department-of-veterans-affairs/mobile-component-library'
 import { StackActions } from '@react-navigation/native'
 import { StackScreenProps } from '@react-navigation/stack/lib/typescript/src/types'
 import { useDispatch, useSelector } from 'react-redux'
@@ -5,7 +6,7 @@ import { useTranslation } from 'react-i18next'
 import React, { FC, useEffect, useState } from 'react'
 
 import { BenefitsStackParamList } from 'screens/BenefitsScreen/BenefitsStackScreens'
-import { Box, ButtonTypesConstants, FieldType, FormFieldType, FormWrapper, LoadingComponent, TextView, VAButton } from 'components'
+import { Box, FieldType, FormFieldType, FormWrapper, LoadingComponent, TextView } from 'components'
 import { ClaimEventData } from 'store/api'
 import { ClaimsAndAppealsState, fileUploadSuccess, uploadFileToClaim } from 'store/slices'
 import { DocumentPickerResponse } from 'screens/BenefitsScreen/BenefitsStackScreens'
@@ -173,13 +174,12 @@ const UploadFile: FC<UploadFileProps> = ({ navigation, route }) => {
           <Box mx={theme.dimensions.gutter} mt={theme.dimensions.standardMarginBetween}>
             <FormWrapper fieldsList={pickerField} onSave={onUpload} onSaveClicked={onSaveClicked} setOnSaveClicked={setOnSaveClicked} />
             <Box mt={theme.dimensions.textAndButtonLargeMargin}>
-              <VAButton
+              <Button
                 onPress={() => {
                   setOnSaveClicked(true)
                 }}
                 label={t('fileUpload.submit')}
                 testID={t('fileUpload.submit')}
-                buttonType={ButtonTypesConstants.buttonPrimary}
               />
             </Box>
           </Box>

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/TakePhotos/TakePhotos.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/TakePhotos/TakePhotos.tsx
@@ -1,10 +1,11 @@
+import { Button } from '@department-of-veterans-affairs/mobile-component-library'
 import { ImagePickerResponse } from 'react-native-image-picker/src/types'
 import { ScrollView } from 'react-native'
 import { StackScreenProps } from '@react-navigation/stack/lib/typescript/src/types'
 import { useTranslation } from 'react-i18next'
 import React, { FC, ReactNode, useRef, useState } from 'react'
 
-import { AlertBox, Box, ButtonTypesConstants, ClickForActionLink, LinkButtonProps, LinkTypeOptionsConstants, LinkUrlIconType, TextArea, TextView, VAButton } from 'components'
+import { AlertBox, Box, ClickForActionLink, LinkButtonProps, LinkTypeOptionsConstants, LinkUrlIconType, TextArea, TextView } from 'components'
 import { BenefitsStackParamList } from 'screens/BenefitsScreen/BenefitsStackScreens'
 import { Events } from 'constants/analytics'
 import { MAX_NUM_PHOTOS } from 'constants/claims'
@@ -111,11 +112,10 @@ const TakePhotos: FC<TakePhotosProps> = ({ navigation, route }) => {
         <TextView variant="MobileBody">{t('fileUpload.acceptedFileTypeOptions')}</TextView>
       </TextArea>
       <Box mt={theme.dimensions.contentMarginTop} mb={theme.dimensions.contentMarginBottom} mx={theme.dimensions.gutter}>
-        <VAButton
+        <Button
           onPress={(): void => onAddPhotos(t, showActionSheetWithOptions, setError, callbackIfUri, 0, claimID, request, setIsActionSheetVisible)}
           label={t('fileUpload.takeOrSelectPhotos')}
           testID={t('fileUpload.takePhotos')}
-          buttonType={ButtonTypesConstants.buttonPrimary}
         />
       </Box>
     </FullScreenSubtask>

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/TakePhotos/UploadOrAddPhotos/UploadOrAddPhotos.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/TakePhotos/UploadOrAddPhotos/UploadOrAddPhotos.tsx
@@ -1,4 +1,5 @@
 import { Asset, ImagePickerResponse } from 'react-native-image-picker/src/types'
+import { Button } from '@department-of-veterans-affairs/mobile-component-library'
 import { Dimensions, ScrollView } from 'react-native'
 import { StackActions } from '@react-navigation/native'
 import { StackScreenProps } from '@react-navigation/stack/lib/typescript/src/types'
@@ -7,7 +8,7 @@ import { useTranslation } from 'react-i18next'
 import React, { FC, ReactElement, useEffect, useRef, useState } from 'react'
 import _ from 'underscore'
 
-import { AlertBox, Box, ButtonTypesConstants, FieldType, FormFieldType, FormWrapper, LoadingComponent, PhotoAdd, PhotoPreview, TextView, VAButton } from 'components'
+import { AlertBox, Box, FieldType, FormFieldType, FormWrapper, LoadingComponent, PhotoAdd, PhotoPreview, TextView } from 'components'
 import { BenefitsStackParamList } from 'screens/BenefitsScreen/BenefitsStackScreens'
 import { ClaimEventData } from 'store/api'
 import { ClaimsAndAppealsState, fileUploadSuccess, uploadFileToClaim } from 'store/slices'
@@ -299,13 +300,12 @@ const UploadOrAddPhotos: FC<UploadOrAddPhotosProps> = ({ navigation, route }) =>
           <Box mx={theme.dimensions.gutter}>
             <FormWrapper fieldsList={pickerField} onSave={onUpload} onSaveClicked={onSaveClicked} setOnSaveClicked={setOnSaveClicked} />
             <Box mt={theme.dimensions.textAndButtonLargeMargin}>
-              <VAButton
+              <Button
                 onPress={() => {
                   setOnSaveClicked(true)
                 }}
                 label={t('fileUpload.submit')}
                 testID={t('fileUpload.submit')}
-                buttonType={ButtonTypesConstants.buttonPrimary}
               />
             </Box>
           </Box>

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimStatus.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimStatus.tsx
@@ -1,7 +1,8 @@
+import { Button } from '@department-of-veterans-affairs/mobile-component-library'
 import { useTranslation } from 'react-i18next'
 import React, { FC, ReactElement, useRef } from 'react'
 
-import { Box, ButtonTypesConstants, SimpleList, SimpleListItemObj, TextArea, TextView, VAButton } from 'components'
+import { Box, SimpleList, SimpleListItemObj, TextArea, TextView } from 'components'
 import { ClaimData } from 'store/api/types'
 import { ClaimType, ClaimTypeConstants } from '../../ClaimsAndAppealsListView/ClaimsAndAppealsListView'
 import { Events } from 'constants/analytics'
@@ -122,7 +123,7 @@ const ClaimStatus: FC<ClaimStatusProps> = ({ claim, claimType }) => {
                 {letterAvailable}
               </TextView>
             </Box>
-            {showButton && <VAButton onPress={onPress} label={t('claimDetails.getClaimLetters')} buttonType={ButtonTypesConstants.buttonPrimary} testID="getClaimLettersTestID" />}
+            {showButton && <Button onPress={onPress} label={t('claimDetails.getClaimLetters')} testID="getClaimLettersTestID" />}
           </TextArea>
         </Box>
       )

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimTimeline/ClaimPhase.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimTimeline/ClaimPhase.tsx
@@ -1,9 +1,10 @@
+import { Button } from '@department-of-veterans-affairs/mobile-component-library'
 import { DateTime } from 'luxon'
 import { TFunction } from 'i18next'
 import { useTranslation } from 'react-i18next'
 import React, { FC, ReactNode, useEffect } from 'react'
 
-import { AccordionCollapsible, Box, ButtonTypesConstants, TextView, VAButton } from 'components'
+import { AccordionCollapsible, Box, TextView } from 'components'
 import { ClaimAttributesData, ClaimEventData } from 'store/api'
 import { Events } from 'constants/analytics'
 import { NAMESPACE } from 'constants/namespaces'
@@ -179,11 +180,10 @@ const ClaimPhase: FC<ClaimPhaseProps> = ({ phase, current, attributes, claimID }
             {youHaveFileRequestsText}
           </TextView>
           <Box mt={standardMarginBetween}>
-            <VAButton
+            <Button
               onPress={fileRequestsPress}
               testID={t('claimPhase.fileRequests.button.label')}
               label={t('claimPhase.fileRequests.button.label')}
-              buttonType={ButtonTypesConstants.buttonPrimary}
               a11yHint={t('claimPhase.fileRequests.button.a11yHint')}
             />
           </Box>

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/EstimatedDecisionDate/EstimatedDecisionDate.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/EstimatedDecisionDate/EstimatedDecisionDate.tsx
@@ -1,8 +1,9 @@
+import { Button } from '@department-of-veterans-affairs/mobile-component-library'
 import { DateTime } from 'luxon'
 import { useTranslation } from 'react-i18next'
 import React, { FC, ReactElement } from 'react'
 
-import { AlertBox, Box, ButtonTypesConstants, TextArea, TextView, VAButton } from 'components'
+import { AlertBox, Box, TextArea, TextView } from 'components'
 import { NAMESPACE } from 'constants/namespaces'
 import { formatDateMMMMDDYYYY } from 'utils/formattingUtils'
 import { testIdProps } from 'utils/accessibility'
@@ -30,11 +31,10 @@ const EstimatedDecisionDate: FC<EstimatedDecisionDateProps> = ({ maxEstDate, sho
     return (
       <AlertBox border="warning" text={t('claimDetails.covidMessage')}>
         <Box mt={theme.dimensions.standardMarginBetween}>
-          <VAButton
+          <Button
             onPress={onAlertLinkPress}
             testID={t('claimDetails.reviewLocations')}
             label={t('claimDetails.reviewLocations')}
-            buttonType={ButtonTypesConstants.buttonPrimary}
             a11yHint={t('claimDetails.reviewLocationsA11yHint')}
           />
         </Box>

--- a/VAMobile/src/screens/BenefitsScreen/Letters/BenefitSummaryServiceVerification/BenefitSummaryServiceVerification.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/Letters/BenefitSummaryServiceVerification/BenefitSummaryServiceVerification.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@department-of-veterans-affairs/mobile-component-library'
 import { StackScreenProps } from '@react-navigation/stack'
 import { map } from 'underscore'
 import { useSelector } from 'react-redux'
@@ -8,7 +9,6 @@ import {
   BasicError,
   Box,
   ButtonDecoratorType,
-  ButtonTypesConstants,
   ClickForActionLink,
   DefaultList,
   DefaultListItemObj,
@@ -20,7 +20,6 @@ import {
   SimpleListItemObj,
   TextArea,
   TextView,
-  VAButton,
 } from 'components'
 import { BenefitSummaryAndServiceVerificationLetterOptions, LetterBenefitInformation, LetterTypeConstants } from 'store/api/types'
 import { BenefitsStackParamList } from 'screens/BenefitsScreen/BenefitsStackScreens'
@@ -252,12 +251,7 @@ const BenefitSummaryServiceVerification: FC<BenefitSummaryServiceVerificationPro
           </Box>
 
           <Box mx={theme.dimensions.gutter}>
-            <VAButton
-              onPress={onViewLetter}
-              label={t('letters.benefitService.viewLetter')}
-              testID={t('letters.benefitService.viewLetter')}
-              buttonType={ButtonTypesConstants.buttonPrimary}
-            />
+            <Button onPress={onViewLetter} label={t('letters.benefitService.viewLetter')} testID={t('letters.benefitService.viewLetter')} />
           </Box>
         </Box>
       )}

--- a/VAMobile/src/screens/BenefitsScreen/Letters/GenericLetter/GenericLetter.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/Letters/GenericLetter/GenericLetter.tsx
@@ -1,8 +1,9 @@
+import { Button } from '@department-of-veterans-affairs/mobile-component-library'
 import { StackScreenProps } from '@react-navigation/stack'
 import { useTranslation } from 'react-i18next'
 import React, { FC } from 'react'
 
-import { AlertBox, BasicError, Box, ButtonTypesConstants, FeatureLandingTemplate, LoadingComponent, TextArea, TextView, VAButton } from 'components'
+import { AlertBox, BasicError, Box, FeatureLandingTemplate, LoadingComponent, TextArea, TextView } from 'components'
 import { BenefitsStackParamList } from 'screens/BenefitsScreen/BenefitsStackScreens'
 import { LetterTypeConstants } from 'store/api/types'
 import { LettersState, downloadLetter } from 'store/slices'
@@ -63,12 +64,7 @@ const GenericLetter: FC<GenericLetterProps> = ({ navigation, route }) => {
           <TextView {...testIdProps(descriptionA11yLabel || description)} variant="MobileBody" mt={theme.dimensions.standardMarginBetween} paragraphSpacing={true}>
             {description}
           </TextView>
-          <VAButton
-            onPress={onViewLetter}
-            label={t('letters.benefitService.viewLetter')}
-            testID={t('letters.benefitService.viewLetter')}
-            buttonType={ButtonTypesConstants.buttonPrimary}
-          />
+          <Button onPress={onViewLetter} label={t('letters.benefitService.viewLetter')} testID={t('letters.benefitService.viewLetter')} />
         </TextArea>
       </Box>
     </FeatureLandingTemplate>

--- a/VAMobile/src/screens/BenefitsScreen/Letters/LettersOverviewScreen.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/Letters/LettersOverviewScreen.tsx
@@ -1,9 +1,10 @@
+import { Button } from '@department-of-veterans-affairs/mobile-component-library'
 import { StackScreenProps } from '@react-navigation/stack'
 import { useTranslation } from 'react-i18next'
 import React, { FC } from 'react'
 
 import { BenefitsStackParamList } from 'screens/BenefitsScreen/BenefitsStackScreens'
-import { Box, ButtonTypesConstants, FeatureLandingTemplate, TextView, VAButton } from 'components'
+import { Box, FeatureLandingTemplate, TextView } from 'components'
 import { Events } from 'constants/analytics'
 import { NAMESPACE } from 'constants/namespaces'
 import { logAnalyticsEvent } from 'utils/analytics'
@@ -55,12 +56,7 @@ const LettersOverviewScreen: FC<LettersOverviewProps> = ({ navigation }) => {
         {t('letters.overview.ifThisAddress')}
       </TextView>
       <Box mx={theme.dimensions.gutter} mb={theme.dimensions.contentMarginBottom}>
-        <VAButton
-          onPress={onViewLetters}
-          label={t('letters.overview.viewLetters')}
-          buttonType={ButtonTypesConstants.buttonPrimary}
-          a11yHint={t('letters.overview.viewLetters.hint')}
-        />
+        <Button onPress={onViewLetters} label={t('letters.overview.viewLetters')} a11yHint={t('letters.overview.viewLetters.hint')} />
       </Box>
     </FeatureLandingTemplate>
   )


### PR DESCRIPTION
## Description of Change
Updated the benefits screens to use the new design systems button component instead of VAButton

## Screenshots/Video
Primary Buttons:
Toggle: <details><summary>Before/after:</summary><img src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/1699cd29-94d3-47b0-b73d-e589a7f6fc13" width="49%" />&nbsp;&nbsp;<img src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/aeecae6b-e260-4534-8f37-0b110c746b8f" width="49%" /></details>
Secondary Buttons:
Toggle: <details><summary>Before/after:</summary><img src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/91e57bd7-5a66-47fa-a3c1-0d424a5dfd8f" width="49%" />&nbsp;&nbsp;<img src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/fd44ddee-00de-49ae-ae04-4bdd976247c4" width="49%" /></details>


## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
VAButton has been replaced with new Button component is implemented in the Benefits screens of the app

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
