### PR TITLE
feature/6228-theo-LoginAnalytics

### DIFF
--- a/VAMobile/src/constants/analytics.ts
+++ b/VAMobile/src/constants/analytics.ts
@@ -586,19 +586,19 @@ export const Events = {
       },
     }
   },
-  vama_login_token_refresh: (status_code: number): Event => {
-    return {
-      name: 'vama_login_token_refresh',
-      params: {
-        status_code,
-      },
-    }
-  },
   vama_login_token_get: (success: boolean): Event => {
     return {
       name: 'vama_login_token_get',
       params: {
         success,
+      },
+    }
+  },
+  vama_login_token_refresh: (status_code: number): Event => {
+    return {
+      name: 'vama_login_token_refresh',
+      params: {
+        status_code,
       },
     }
   },

--- a/VAMobile/src/constants/analytics.ts
+++ b/VAMobile/src/constants/analytics.ts
@@ -578,6 +578,38 @@ export const Events = {
       },
     }
   },
+  vama_login_token_get: (status_code: number): Event => {
+    return {
+      name: 'vama_login_token_get',
+      params: {
+        status_code,
+      },
+    }
+  },
+  vama_login_token_refresh: (status_code: number): Event => {
+    return {
+      name: 'vama_login_token_refresh',
+      params: {
+        status_code,
+      },
+    }
+  },
+  vama_login_token_retrieve: (success: boolean): Event => {
+    return {
+      name: 'vama_login_token_retrieve',
+      params: {
+        success,
+      },
+    }
+  },
+  vama_login_token_store: (success: boolean): Event => {
+    return {
+      name: 'vama_login_token_store',
+      params: {
+        success,
+      },
+    }
+  },
   vama_modalpick_open: (modal: string): Event => {
     return {
       name: 'vama_modalpick_open',
@@ -959,6 +991,14 @@ export const Events = {
       params: {
         totalTime,
         actionTime,
+      },
+    }
+  },
+  vama_user_call: (status_code: number): Event => {
+    return {
+      name: 'vama_user_call',
+      params: {
+        status_code,
       },
     }
   },

--- a/VAMobile/src/constants/analytics.ts
+++ b/VAMobile/src/constants/analytics.ts
@@ -578,9 +578,9 @@ export const Events = {
       },
     }
   },
-  vama_login_token_get: (status_code: number): Event => {
+  vama_login_token_fetch: (status_code: number): Event => {
     return {
-      name: 'vama_login_token_get',
+      name: 'vama_login_token_fetch',
       params: {
         status_code,
       },
@@ -594,9 +594,9 @@ export const Events = {
       },
     }
   },
-  vama_login_token_retrieve: (success: boolean): Event => {
+  vama_login_token_get: (success: boolean): Event => {
     return {
-      name: 'vama_login_token_retrieve',
+      name: 'vama_login_token_get',
       params: {
         success,
       },

--- a/VAMobile/src/store/slices/authSlice.ts
+++ b/VAMobile/src/store/slices/authSlice.ts
@@ -319,11 +319,11 @@ const retrieveRefreshToken = async (): Promise<string | undefined> => {
   try {
     console.debug('retrieveRefreshToken')
     const result = await Promise.all([AsyncStorage.getItem(REFRESH_TOKEN_ENCRYPTED_COMPONENT_KEY), Keychain.getInternetCredentials(KEYCHAIN_STORAGE_KEY)])
-    await logAnalyticsEvent(Events.vama_login_token_retrieve(true))
+    await logAnalyticsEvent(Events.vama_login_token_get(true))
     const reconstructedToken = result[0] && result[1] ? `${result[0]}.${result[1].password}.V0` : undefined
     return reconstructedToken
   } catch {
-    await logAnalyticsEvent(Events.vama_login_token_retrieve(false))
+    await logAnalyticsEvent(Events.vama_login_token_get(false))
   }
 }
 
@@ -665,7 +665,7 @@ export const handleTokenCallbackUrl =
         logNonFatalErrorToFirebase(error, `handleTokenCallbackUrl: ${authNonFatalErrorString}`)
         await logAnalyticsEvent(Events.vama_exchange_failed())
         if (error.status) {
-          await logAnalyticsEvent(Events.vama_login_token_get(error.status))
+          await logAnalyticsEvent(Events.vama_login_token_fetch(error.status))
         }
         dispatch(dispatchFinishAuthLogin({ error }))
       }

--- a/VAMobile/src/store/slices/authSlice.ts
+++ b/VAMobile/src/store/slices/authSlice.ts
@@ -319,8 +319,9 @@ const retrieveRefreshToken = async (): Promise<string | undefined> => {
   try {
     console.debug('retrieveRefreshToken')
     const result = await Promise.all([AsyncStorage.getItem(REFRESH_TOKEN_ENCRYPTED_COMPONENT_KEY), Keychain.getInternetCredentials(KEYCHAIN_STORAGE_KEY)])
-    await logAnalyticsEvent(Events.vama_login_token_get(true))
     const reconstructedToken = result[0] && result[1] ? `${result[0]}.${result[1].password}.V0` : undefined
+
+    await logAnalyticsEvent(Events.vama_login_token_get(true))
     return reconstructedToken
   } catch {
     await logAnalyticsEvent(Events.vama_login_token_get(false))


### PR DESCRIPTION
<!-- NOTE: Please include the related issue number in the PR title, otherwise the changes won't be merged 
into the `staging` branch upon ticket completion. E.g. '[Issue type]/[Issue #]-[Your name]-[Summary of issue]',
where Issue type = bug, feature, spike, CU (code upkeep), etc. -->

## Description of Change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, 
need to know about this PR in order to understand why this PR was created? This could include dependencies 
introduced, changes in behavior, pointers to more detailed documentation. The description should be more 
than a link to an issue.  -->
Adds login analytics.

**Note**: `vama_login_token_retrieve` was too long, so I decided to rename this to `vama_login_token_get` and renamed the original `vama_login_token_get` to `vama_login_token_fetch`. This also better distinguishes getting the token from async storage (`vama_login_token_get`) vs fetching it from the API (`vama_login_token_fetch`).

## Screenshots/Video
<!-- Add screenshots or video as needed. Before/after if changes are to be compared by reviewers.
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Toggle: <details><summary></summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>
-->
N/A

## Testing
<!-- What testing was done to verify the changes (local/unit)? What testing remains? Note edge cases, or special
situations that could not be tested during development. -->

- [ ] Tested on iOS <!-- simulator is fine -->
- [ ] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
<!-- What should reviewers look for? Copy/paste Acceptance Criteria from ticket -->
- [ ] `vama_user_call`: Return the response code of the API call to the user endpoint in a param outcome
     - [ ] `status_code`: status code from the API return

- [ ] `vama_login_token_fetch`: Returns the response code of the request for access and refresh tokens on /token endpoint
    - [ ] `status_code`: status code returned from the /token endpoint

- [ ] `vama_login_token_store`: Return whether or not the app's attempt to store tokens in app storage succeeded
     - [ ] `success`: true if tokens stored (should be in the try statement), false if not (in the catch statement)

- [ ] `vama_login_token_get (check length)`: Return whether or not the the app's attempt to retrieve tokens in app storage
     - [ ] `success`: true if token retrieved, false if not

- [ ] `vama_login_token_refresh`: Return the response code of the call to the /refresh endpoint
     - [ ] `status_code`: status code returned from the /refresh endpoint

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [ ] PR is connected to issue(s)
- [ ] Tests are included to cover this change (when possible)
- [ ] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [ ] No secrets or API keys are checked in
- [ ] All imports are absolute (no relative imports)
- [ ] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
