### PR TITLE
Revert "Fix/7822-TimW-Add a retry for Fastlane in the iOS build workflow"

### DIFF
--- a/.github/workflows/build_ios.yml
+++ b/.github/workflows/build_ios.yml
@@ -112,12 +112,8 @@ jobs:
         run: bundle install
       - name: Update fastlane
         run: bundle update fastlane
-      - name: Run fastlane with retries
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 20
-          max_attempts: 3
-          command: bundle exec fastlane ${{ inputs.lane }} version:"${{ inputs.version }}" notes:"${{ inputs.notes }}" tfGroup:"${{ inputs.tf_group }}" --verbose
+      - name: Run fastlane
+        run: bundle exec fastlane ${{ inputs.lane }} version:"${{ inputs.version }}" notes:"${{ inputs.notes }}" tfGroup:"${{ inputs.tf_group }}" --verbose
       - name: Setup tmate session
         if: ${{ failure() }}
         uses: mxschmitt/action-tmate@v3


### PR DESCRIPTION
Build is having trouble finding the gemfile and I don't want to leave it over the weekend

Reverts department-of-veterans-affairs/va-mobile-app#7823