### PR TITLE
bug/7996-Dylan-FixDemoModeClaimsAndAppeals

### DIFF
--- a/VAMobile/src/store/api/demo/mocks/appointments.json
+++ b/VAMobile/src/store/api/demo/mocks/appointments.json
@@ -3030,7 +3030,7 @@
         "pagination": {
           "currentPage": 1,
           "perPage": 10,
-          "totalPages": 6,
+          "totalPages": 7,
           "totalEntries": 65
         }
       },
@@ -5344,8 +5344,8 @@
         "pagination": {
           "currentPage": 1,
           "perPage": 10,
-          "totalPages": 1,
-          "totalEntries": 8
+          "totalPages": 5,
+          "totalEntries": 48
         }
       },
       "links": {

--- a/VAMobile/src/store/api/demo/mocks/claims.json
+++ b/VAMobile/src/store/api/demo/mocks/claims.json
@@ -470,8 +470,8 @@
         "pagination": {
           "currentPage": 1,
           "perPage": 10,
-          "totalPages": 1,
-          "totalEntries": 1
+          "totalPages": 5,
+          "totalEntries": 42
         }
       },
       "links": {


### PR DESCRIPTION
## Description of Change
fixes demo mode claims and appeals data and appts upcoming and past, previously it was only showing 10 claims and appeals when there are 42 in the json.

## Screenshots/Video
N/A

## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
demo mode claims and appeals are fixed

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
