### PR TITLE
feature/7291-Dylan-MoreGithubEnhancements

### DIFF
--- a/.github/workflows/label_pull_request_onCreate.yml
+++ b/.github/workflows/label_pull_request_onCreate.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   needs_review:
+    if: github.event.requested_team.name == 'flagship-mobile-reviewers' && github.event.pull_request.draft == false
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest

--- a/.github/workflows/label_pull_request_onCreate.yml
+++ b/.github/workflows/label_pull_request_onCreate.yml
@@ -1,0 +1,21 @@
+# Workflow that labels a pr with the correct label
+name: "[Github Management] Pull Request Labeler on create or taken out of draft"
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  needs_review:
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Add FE-Needs Reviewv
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} --add-label "FE-Needs Review"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label_pull_request_onReview.yml
+++ b/.github/workflows/label_pull_request_onReview.yml
@@ -20,3 +20,52 @@ jobs:
           gh pr edit ${{ github.event.pull_request.number }}  --remove-label "FE-Needs Review,FE-With QA" --add-label "FE-Changes Requested"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  review_dismissed:
+    if: github.event.review.state == 'dismissed'
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Remove old labels and add FE-Needs Review
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }}  --remove-label "FE-Changes Requested,FE-With QA" --add-label "FE-Needs Review"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  approved:
+    if: github.event.review.state == 'approved'
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      
+      - name: Check approvals and add correct labels
+        shell: bash
+        run: |
+          approvals=$(curl --request GET \
+          --url https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews?per_page=100 \
+          --header 'Authorization: ${{ secrets.GITHUB_TOKEN }}' \
+          --header 'Content-Type: application/json' |
+          jq -c '[map(select(.state == "APPROVED")) | .[] .user.login]')
+          echo "Approvers: $approvals"
+          echo "${{secrets.GH_ACTIONS_PAT}}" >> token.txt
+
+          if [[ $(jq '. | length' <<< "$approvals") -ge 1 ]]
+            then
+              if [[ $(jq '[.[] | select(. | IN("timwright12", "rbontrager", "DJUltraTom", "TKDickson"))] | length' <<< "$approvals") -gt 0 ]]
+                then
+                echo 'This PR has QA approval and one other'
+                gh pr edit ${{ github.event.pull_request.number }}  --remove-label "FE-With QA" --add-label "FE-Ready to Merge" --with-token < token.txt
+              else 
+                echo 'This PR requires QA approval'
+                gh pr edit ${{ github.event.pull_request.number }}  --remove-label "FE-Needs Review" --add-label "FE-With QA" --with-token < token.txt
+              fi
+          else
+            echo 'This PR requires 2 approvals, including one QA approval'
+          fi
+          

--- a/.github/workflows/label_pull_request_onReview.yml
+++ b/.github/workflows/label_pull_request_onReview.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Remove old labels and add FE-Needs Review
         run: |
-          gh pr edit ${{ github.event.pull_request.number }}  --remove-label "FE-Changes Requested,FE-With QA" --add-label "FE-Needs Review"
+          gh pr edit ${{ github.event.pull_request.number }}  --remove-label "FE-Changes Requested" --add-label "FE-Needs Review"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -60,7 +60,7 @@ jobs:
               if [[ $(jq '[.[] | select(. | IN("timwright12", "rbontrager", "DJUltraTom", "TKDickson"))] | length' <<< "$approvals") -gt 0 ]]
                 then
                 echo 'This PR has QA approval and one other'
-                gh pr edit ${{ github.event.pull_request.number }}  --remove-label "FE-With QA" --add-label "FE-Ready to Merge" --with-token < token.txt
+                gh pr edit ${{ github.event.pull_request.number }}  --remove-label "FE-Needs Review,FE-With QA" --add-label "FE-Ready to Merge" --with-token < token.txt
               else 
                 echo 'This PR requires QA approval'
                 gh pr edit ${{ github.event.pull_request.number }}  --remove-label "FE-Needs Review" --add-label "FE-With QA" --with-token < token.txt
@@ -68,4 +68,3 @@ jobs:
           else
             echo 'This PR requires 2 approvals, including one QA approval'
           fi
-          

--- a/.github/workflows/label_pull_request_onReview.yml
+++ b/.github/workflows/label_pull_request_onReview.yml
@@ -53,18 +53,19 @@ jobs:
           --header 'Content-Type: application/json' |
           jq -c '[map(select(.state == "APPROVED")) | .[] .user.login]')
           echo "Approvers: $approvals"
-          echo "${{secrets.GH_ACTIONS_PAT}}" >> token.txt
 
           if [[ $(jq '. | length' <<< "$approvals") -ge 1 ]]
             then
               if [[ $(jq '[.[] | select(. | IN("timwright12", "rbontrager", "DJUltraTom", "TKDickson"))] | length' <<< "$approvals") -gt 0 ]]
                 then
                 echo 'This PR has QA approval and one other'
-                gh pr edit ${{ github.event.pull_request.number }}  --remove-label "FE-Needs Review,FE-With QA" --add-label "FE-Ready to Merge" --with-token < token.txt
+                gh pr edit ${{ github.event.pull_request.number }}  --remove-label "FE-Needs Review,FE-With QA" --add-label "FE-Ready to Merge"
               else 
                 echo 'This PR requires QA approval'
-                gh pr edit ${{ github.event.pull_request.number }}  --remove-label "FE-Needs Review" --add-label "FE-With QA" --with-token < token.txt
+                gh pr edit ${{ github.event.pull_request.number }}  --remove-label "FE-Needs Review" --add-label "FE-With QA"
               fi
           else
             echo 'This PR requires 2 approvals, including one QA approval'
           fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description of Change
New Github automations. On new pr's or one's taken out of draft apply FE-Needs Review Label

on review dismissed apply fe-needs review and remove changes requested label

on reviews if QA approval move add fe ready to merge and drop needs review or with qa

if eng approval drop fe needs review and add fe with qa

## Screenshots/Video
N/A

## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
The state of the submitted review. Can be one of: commented, changes_requested, approved or dismissed.

See changes requested workflow and create a new workflow for approvals

When 1 approval from an Engineer apply the FE-With QA label and remove the FE-Needs Review label
When 2 approvals from an Engineer and QA apply the FE-Ready to Merge label and removes the FE-With QA label

create a workflow on review dismissed to drop all FE-With QA and FE-Changes Requested and applies FE-Needs Review
Research in this ticket

create a workflow that when pr created and not a draft it applies FE-Needs Review and one that when draft is marked as ready applies FE-Needs Review

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
