### PR TITLE
bug/7461-Dylan-ContradictorySlackMessagesOnE2ETests

### DIFF
--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -200,6 +200,7 @@ jobs:
         run: yarn e2e:android-build
 
       - name: Run e2e tests for Android
+        id: run_e2e_tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           working-directory: VAMobile
@@ -220,7 +221,7 @@ jobs:
           
       - name: Inform Slack of Failure
         id: post_failure
-        if: failure() && github.event_name == 'schedule'
+        if: steps.run_e2e_tests.outcome == 'failure' && github.event_name == 'schedule'
         run: |
           ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \
             -H 'Content-type: application/json' \
@@ -231,7 +232,7 @@ jobs:
 
       - name: Inform Slack of success
         id: post_success
-        if: ${{ success() }} && github.event_name == 'schedule'
+        if: steps.run_e2e_tests.outcome == 'success' && github.event_name == 'schedule'
         run: |
           ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \
             -H 'Content-type: application/json' \

--- a/.github/workflows/e2e_ios.yml
+++ b/.github/workflows/e2e_ios.yml
@@ -206,7 +206,7 @@ jobs:
 
       - name: Inform Slack of Failure
         id: post_failure
-        if: failure() && github.event_name == 'schedule'
+        if: steps.run_e2e_tests.outcome == 'failure' && github.event_name == 'schedule'
         run: |
           ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \
             -H 'Content-type: application/json' \
@@ -217,7 +217,7 @@ jobs:
 
       - name: Inform Slack of success
         id: post_success
-        if: ${{ success() }} && github.event_name == 'schedule'
+        if: steps.run_e2e_tests.outcome == 'success' && github.event_name == 'schedule'
         run: |
           ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \
             -H 'Content-type: application/json' \


### PR DESCRIPTION
## Description of Change
Fixes where the failure message is sent followed by the success by specifically checking the e2e test outcome instead of having an other steps success effect on the outcome

## Screenshots/Video
N/A

## Testing

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
Should not send success message after a failure message has been sent and should be based off the result of the e2e test step

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
