### PR TITLE
bug/8044-Dylan-SpecialCharactersSecureMessagingFix

### DIFF
--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/ViewMessage/CollapsibleMessage.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/ViewMessage/CollapsibleMessage.tsx
@@ -20,7 +20,7 @@ import { SecureMessagingState, downloadFileAttachment, getMessage } from 'store/
 import { bytesToFinalSizeDisplay, bytesToFinalSizeDisplayA11y } from 'utils/common'
 import { getFormattedDateAndTimeZone } from 'utils/formattingUtils'
 import { useAppDispatch, useExternalLink, useIsScreenReaderEnabled, useTheme } from 'utils/hooks'
-import { getLinkifiedText } from 'utils/secureMessaging'
+import { fixSpecialCharacters, getLinkifiedText } from 'utils/secureMessaging'
 
 import IndividualMessageErrorComponent from './IndividualMessageErrorComponent'
 
@@ -71,7 +71,7 @@ function CollapsibleMessage({ message, isInitialMessage, collapsibleMessageRef }
     /** this does preserve newline characters just not spaces
      * TODO: change the mobile body link text views to be clickable and launch the right things */
     if (body) {
-      return getLinkifiedText(body, t, launchLink)
+      return getLinkifiedText(fixSpecialCharacters(body), t, launchLink)
     }
     return <></>
   }

--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/ViewMessage/CollapsibleMessage.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/ViewMessage/CollapsibleMessage.tsx
@@ -20,7 +20,8 @@ import { SecureMessagingState, downloadFileAttachment, getMessage } from 'store/
 import { bytesToFinalSizeDisplay, bytesToFinalSizeDisplayA11y } from 'utils/common'
 import { getFormattedDateAndTimeZone } from 'utils/formattingUtils'
 import { useAppDispatch, useExternalLink, useIsScreenReaderEnabled, useTheme } from 'utils/hooks'
-import { fixSpecialCharacters, getLinkifiedText } from 'utils/secureMessaging'
+import { fixSpecialCharacters } from 'utils/jsonFormatting'
+import { getLinkifiedText } from 'utils/secureMessaging'
 
 import IndividualMessageErrorComponent from './IndividualMessageErrorComponent'
 

--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/ViewMessage/MessageCard.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/ViewMessage/MessageCard.tsx
@@ -18,7 +18,8 @@ import { logAnalyticsEvent } from 'utils/analytics'
 import { bytesToFinalSizeDisplay, bytesToFinalSizeDisplayA11y } from 'utils/common'
 import { getFormattedDateAndTimeZone } from 'utils/formattingUtils'
 import { useAppDispatch, useExternalLink, useRouteNavigation, useTheme } from 'utils/hooks'
-import { fixSpecialCharacters, formatSubject, getLinkifiedText } from 'utils/secureMessaging'
+import { fixSpecialCharacters } from 'utils/jsonFormatting'
+import { formatSubject, getLinkifiedText } from 'utils/secureMessaging'
 
 export type MessageCardProps = {
   /* message object */

--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/ViewMessage/MessageCard.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/ViewMessage/MessageCard.tsx
@@ -18,7 +18,7 @@ import { logAnalyticsEvent } from 'utils/analytics'
 import { bytesToFinalSizeDisplay, bytesToFinalSizeDisplayA11y } from 'utils/common'
 import { getFormattedDateAndTimeZone } from 'utils/formattingUtils'
 import { useAppDispatch, useExternalLink, useRouteNavigation, useTheme } from 'utils/hooks'
-import { formatSubject, getLinkifiedText } from 'utils/secureMessaging'
+import { fixSpecialCharacters, formatSubject, getLinkifiedText } from 'utils/secureMessaging'
 
 export type MessageCardProps = {
   /* message object */
@@ -67,7 +67,7 @@ function MessageCard({ message }: MessageCardProps) {
     /** this does preserve newline characters just not spaces
      * TODO: change the mobile body link text views to be clickable and launch the right things */
     if (body) {
-      return getLinkifiedText(body, t, launchLink)
+      return getLinkifiedText(fixSpecialCharacters(body), t, launchLink)
     }
     return <></>
   }

--- a/VAMobile/src/store/api/demo/mocks/secureMessaging.json
+++ b/VAMobile/src/store/api/demo/mocks/secureMessaging.json
@@ -455,7 +455,7 @@
         "messageId": 2092803,
         "category": "COVID",
         "subject": "Your requested info",
-        "body": "Here is the information about COVID vaccines that you requested.  Let us know if you have any questions.\r\n\r\nDr. Duma\r\n",
+        "body": "Special character testing\nAmpersand: &amp;\nDouble Quotes: &ldquo;\nSingle Quote: &rsquo;",
         "hasAttachments": true,
         "attachment": true,
         "sentDate": "2021-10-26T22:21:11.000Z",

--- a/VAMobile/src/utils/jsonFormatting.ts
+++ b/VAMobile/src/utils/jsonFormatting.ts
@@ -20,7 +20,7 @@ export const fixedWhiteSpaceString = (text: string | undefined) => {
 
 export const fixSpecialCharacters = (text: string): string => {
   return text
-    .replace(/\&amp;/g, '&')
+    .replace(/&amp;/g, '&')
     .replace(/&ldquo;/g, '"')
     .replace(/&rsquo;/g, "'")
 }

--- a/VAMobile/src/utils/jsonFormatting.ts
+++ b/VAMobile/src/utils/jsonFormatting.ts
@@ -20,7 +20,7 @@ export const fixedWhiteSpaceString = (text: string | undefined) => {
 
 export const fixSpecialCharacters = (text: string): string => {
   return text
-    .replace(/&amp;/g, '&')
+    .replace(/\\&amp;/g, '&')
     .replace(/&ldquo;/g, '"')
     .replace(/&rsquo;/g, "'")
 }

--- a/VAMobile/src/utils/jsonFormatting.ts
+++ b/VAMobile/src/utils/jsonFormatting.ts
@@ -20,7 +20,7 @@ export const fixedWhiteSpaceString = (text: string | undefined) => {
 
 export const fixSpecialCharacters = (text: string): string => {
   return text
-    .replace(/\\&amp;/g, '&')
+    .replace(/\&amp;/g, '&')
     .replace(/&ldquo;/g, '"')
     .replace(/&rsquo;/g, "'")
 }

--- a/VAMobile/src/utils/jsonFormatting.ts
+++ b/VAMobile/src/utils/jsonFormatting.ts
@@ -17,3 +17,10 @@ export const fixedWhiteSpaceString = (text: string | undefined) => {
   }
   return ''
 }
+
+export const fixSpecialCharacters = (text: string): string => {
+  return text
+    .replace(/&amp;/g, '&')
+    .replace(/&ldquo;/g, '"')
+    .replace(/&rsquo;/g, "'")
+}

--- a/VAMobile/src/utils/secureMessaging.tsx
+++ b/VAMobile/src/utils/secureMessaging.tsx
@@ -482,13 +482,6 @@ export const saveDraftWithAttachmentAlert = (
   }
 }
 
-export const fixSpecialCharacters = (text: string): string => {
-  return text
-    .replace(/&amp;/g, '&')
-    .replace(/&ldquo;/g, '"')
-    .replace(/&rsquo;/g, "'")
-}
-
 export const getLinkifiedText = (
   body: string,
   t: TFunction,

--- a/VAMobile/src/utils/secureMessaging.tsx
+++ b/VAMobile/src/utils/secureMessaging.tsx
@@ -482,6 +482,13 @@ export const saveDraftWithAttachmentAlert = (
   }
 }
 
+export const fixSpecialCharacters = (text: string): string => {
+  return text
+    .replace(/&amp;/g, '&')
+    .replace(/&ldquo;/g, '"')
+    .replace(/&rsquo;/g, "'")
+}
+
 export const getLinkifiedText = (
   body: string,
   t: TFunction,


### PR DESCRIPTION
## Description of Change
Fixes & " and ' special characters in secure messages

## Screenshots/Video
<img width="474" alt="Screenshot 2024-03-28 at 9 35 55 AM" src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/da135b03-9953-4719-bb57-3443b5934cdc">


## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
All special characters should render correctly

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
