### PR TITLE
bug/8191-Dylan-TypeOfCareNotUsingHealthcareServiceFallback

### DIFF
--- a/.github/workflows/build_ios.yml
+++ b/.github/workflows/build_ios.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: 15.2
       - name: Setup node and restore yarn cache
         uses: actions/setup-node@v3
         with:

--- a/VAMobile/src/screens/HealthScreen/Appointments/AppointmentDetailsCommon/TypeOfCare.test.tsx
+++ b/VAMobile/src/screens/HealthScreen/Appointments/AppointmentDetailsCommon/TypeOfCare.test.tsx
@@ -8,21 +8,15 @@ import { defaultAppointmentAttributes } from 'utils/tests/appointments'
 import TypeOfCare from './TypeOfCare'
 
 context('TypeOfCare', () => {
-  const initializeTestInstance = (phoneOnly = false, typeOfCare?: string, healthcareService?: string): void => {
+  const initializeTestInstance = (phoneOnly = false, typeOfCare?: string): void => {
     const props = {
       ...defaultAppointmentAttributes,
-      healthcareService: healthcareService,
       phoneOnly: phoneOnly,
       typeOfCare: typeOfCare,
     }
 
     render(<TypeOfCare attributes={props} />)
   }
-
-  it('When a appointment with no type of care noted it should render correctly', () => {
-    initializeTestInstance(true, undefined, 'phone consult')
-    expect(screen.getByRole('header', { name: 'phone consult' })).toBeTruthy()
-  })
 
   it('When a appointment with no type of care or healthcare service noted it should render correctly', () => {
     initializeTestInstance(true)

--- a/VAMobile/src/screens/HealthScreen/Appointments/AppointmentDetailsCommon/TypeOfCare.tsx
+++ b/VAMobile/src/screens/HealthScreen/Appointments/AppointmentDetailsCommon/TypeOfCare.tsx
@@ -14,8 +14,7 @@ function TypeOfCare({ attributes }: TypeOfCareProps) {
   const { t } = useTranslation(NAMESPACE.COMMON)
   const theme = useTheme()
 
-  const { typeOfCare, phoneOnly, appointmentType, serviceCategoryName, healthcareService } =
-    attributes || ({} as AppointmentAttributes)
+  const { typeOfCare, phoneOnly, appointmentType, serviceCategoryName } = attributes || ({} as AppointmentAttributes)
 
   if (
     phoneOnly ||
@@ -23,11 +22,7 @@ function TypeOfCare({ attributes }: TypeOfCareProps) {
   ) {
     return (
       <TextView variant="MobileBodyBold" accessibilityRole="header" mb={theme.dimensions.standardMarginBetween}>
-        {typeOfCare && typeOfCare.length > 1
-          ? typeOfCare
-          : healthcareService && healthcareService.length > 1
-            ? healthcareService
-            : t('appointments.noTypeOfCare')}
+        {typeOfCare && typeOfCare.length > 1 ? typeOfCare : t('appointments.noTypeOfCare')}
       </TextView>
     )
   }

--- a/VAMobile/src/screens/HealthScreen/Appointments/PastAppointments/PastAppointmentDetails.test.tsx
+++ b/VAMobile/src/screens/HealthScreen/Appointments/PastAppointments/PastAppointmentDetails.test.tsx
@@ -71,7 +71,7 @@ context('PastAppointmentDetails', () => {
     expect(screen.getByRole('header', { name: 'Past in-person appointment' })).toBeTruthy()
     expect(screen.getByText('This appointment happened in the past.')).toBeTruthy()
     expect(screen.getByText('Saturday, February 6, 2021\n11:53 AM PST')).toBeTruthy()
-    expect(screen.getByRole('header', { name: 'Blind Rehabilitation Center' })).toBeTruthy()
+    expect(screen.getByRole('header', { name: 'Type of care not noted' })).toBeTruthy()
     expect(screen.getByRole('header', { name: 'Provider' })).toBeTruthy()
     expect(screen.getByText('Provider not noted')).toBeTruthy()
     expect(screen.getAllByRole('header', { name: 'VA Long Beach Healthcare System' })).toBeTruthy()

--- a/VAMobile/src/utils/appointments.tsx
+++ b/VAMobile/src/utils/appointments.tsx
@@ -313,7 +313,6 @@ export const getTextLinesForAppointmentListItem = (
     typeOfCare,
     healthcareProvider,
     serviceCategoryName,
-    healthcareService,
   } = attributes
   const textLines: Array<TextLineWithIconProps> = []
   const { condensedMarginBetween } = theme.dimensions
@@ -344,9 +343,7 @@ export const getTextLinesForAppointmentListItem = (
       },
       {
         text: t('text.raw', {
-          text: isCovidVaccine
-            ? t('upcomingAppointments.covidVaccine')
-            : typeOfCare || healthcareService || t('appointments.noTypeOfCare'),
+          text: isCovidVaccine ? t('upcomingAppointments.covidVaccine') : typeOfCare || t('appointments.noTypeOfCare'),
         }),
         variant: 'HelperText',
         mb: 5,


### PR DESCRIPTION
## Description of Change
Removed healthCare Service as a fallback for type of care screenshot shows it as Blind Rehabilitation Center

## Screenshots/Video
Toggle: <details><summary>Before/after:</summary><img src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/a69e36ba-65c3-4358-a977-b8785030d417" width="49%" />&nbsp;&nbsp;<img src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/b3d007ea-55b5-4cfa-aa7a-ba53b5fe50f6" width="49%" /></details>

## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
When the typeOfCare field is null, we should show the null copy. We should not be using the healthcareService attribute as a back up for when typeOfCare is null.

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
