### PR TITLE
bug/7555-Dylan-SwappedAskForClaimDecisionAnalytics

### DIFF
--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/AskForClaimDecision/AskForClaimDecision.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/AskForClaimDecision/AskForClaimDecision.tsx
@@ -107,7 +107,7 @@ function AskForClaimDecision({ navigation, route }: AskForClaimDecisionProps) {
 
   const onSubmit = (): void => {
     if (claim) {
-      logAnalyticsEvent(Events.vama_claim_eval_submit(claim.id, claim.attributes.claimType, numberOfRequests))
+      logAnalyticsEvent(Events.vama_claim_eval_conf(claim.id, claim.attributes.claimType, numberOfRequests))
     }
     const mutateOptions = {
       onSuccess: () => {
@@ -121,7 +121,7 @@ function AskForClaimDecision({ navigation, route }: AskForClaimDecisionProps) {
 
   const onRequestEvaluation = (): void => {
     if (claim) {
-      logAnalyticsEvent(Events.vama_claim_eval_conf(claim.id, claim.attributes.claimType, numberOfRequests))
+      logAnalyticsEvent(Events.vama_claim_eval_submit(claim.id, claim.attributes.claimType, numberOfRequests))
     }
     requestEvalAlert({
       title: t('askForClaimDecision.alertTitle'),


### PR DESCRIPTION
## Description of Change
Turns out these two analytics were in the opposite place as they were supposed to be so swapped them
vama_claim_eval_conf  vama_claim_eval_submit

## Screenshots/Video
N/A

## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
Event vama_claim_eval_submit should track when the user clicks "Request claim evaluation" on the Claim evaluation screen.
Then, the user must perform a confirmation click in their native UI. That click should be captured by vama_claim_eval_conf.

Since vama_claim_eval_conf comes after vama_claim_eval_submit, the count for vama_claim_eval_submit should be greater than or equal to the count for vama_claim_eval_conf. However, the opposite is happening. This means, something is wrong with the logic with one or both of these events.

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
