### PR TITLE
bug/8292-Dylan-FixingRQDowntimeAlert

### DIFF
--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimLettersScreen/ClaimLettersScreen.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimLettersScreen/ClaimLettersScreen.tsx
@@ -95,7 +95,7 @@ const ClaimLettersScreen = ({ navigation }: ClaimLettersScreenProps) => {
 
   return (
     <FeatureLandingTemplate backLabel={backLabel} backLabelOnPress={navigation.goBack} title={t('claimLetters.title')}>
-      {letterInfoError ? (
+      {letterInfoError || claimsInDowntime ? (
         <ErrorComponent screenID={ScreenIDTypesConstants.DECISION_LETTERS_LIST_SCREEN_ID} onTryAgain={fetchInfoAgain} />
       ) : loading || downloading ? (
         <LoadingComponent text={t(loading ? 'claimLetters.loading' : 'claimLetters.downloading')} />

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimsHistoryScreen/ClaimsHistoryScreen.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimsHistoryScreen/ClaimsHistoryScreen.tsx
@@ -124,7 +124,9 @@ function ClaimsHistoryScreen({ navigation }: IClaimsHistoryScreen) {
       backLabelOnPress={navigation.goBack}
       title={title}
       testID="claimsHistoryID">
-      {claimsAndAppealsListError || getUserAuthorizedServicesError ? (
+      {claimsAndAppealsListError ||
+      getUserAuthorizedServicesError ||
+      (!claimsNotInDowntime && !appealsNotInDowntime) ? (
         <ErrorComponent onTryAgain={fetchInfoAgain} screenID={ScreenIDTypesConstants.CLAIMS_HISTORY_SCREEN_ID} />
       ) : loadingClaimsAndAppealsList || loadingUserAuthorizedServices ? (
         <LoadingComponent text={t('claimsAndAppeals.loadingClaimsAndAppeals')} />

--- a/VAMobile/src/screens/BenefitsScreen/DisabilityRatingsScreen/DisabilityRatingsScreen.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/DisabilityRatingsScreen/DisabilityRatingsScreen.tsx
@@ -188,7 +188,7 @@ function DisabilityRatingsScreen() {
       backLabelOnPress={navigation.goBack}
       title={t('disabilityRatingDetails.title')}
       testID="disabilityRatingTestID">
-      {useDisabilityRatingError ? (
+      {useDisabilityRatingError || !drNotInDowntime ? (
         <ErrorComponent screenID={ScreenIDTypesConstants.DISABILITY_RATING_SCREEN_ID} />
       ) : loading ? (
         <LoadingComponent text={t('disabilityRating.loading')} />

--- a/VAMobile/src/screens/BenefitsScreen/Letters/LettersListScreen.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/Letters/LettersListScreen.tsx
@@ -135,7 +135,7 @@ function LettersListScreen({ navigation }: LettersListScreenProps) {
       backLabelOnPress={navigation.goBack}
       title={t('letters.overview.viewLetters')}
       {...testIdProps('Letters-list-page')}>
-      {errorCheck ? (
+      {errorCheck || !lettersNotInDowntime ? (
         <ErrorComponent screenID={ScreenIDTypesConstants.LETTERS_LIST_SCREEN_ID} />
       ) : loading || loadingUserAuthorizedServices ? (
         <LoadingComponent text={t('letters.list.loading')} />

--- a/VAMobile/src/screens/HealthScreen/Vaccines/VaccineList/VaccineListScreen.tsx
+++ b/VAMobile/src/screens/HealthScreen/Vaccines/VaccineList/VaccineListScreen.tsx
@@ -18,12 +18,11 @@ import {
   TextLine,
 } from 'components'
 import { NAMESPACE } from 'constants/namespaces'
-import { DowntimeFeatureTypeConstants } from 'store/api'
 import { ScreenIDTypesConstants } from 'store/api/types/Screens'
 import { a11yLabelVA } from 'utils/a11yLabel'
 import { getA11yLabelText } from 'utils/common'
 import { formatDateMMMMDDYYYY } from 'utils/formattingUtils'
-import { useDowntime, useRouteNavigation, useTheme } from 'utils/hooks'
+import { useError, useRouteNavigation, useTheme } from 'utils/hooks'
 import { screenContentAllowed } from 'utils/waygateConfig'
 
 import { HealthStackParamList } from '../../HealthStackScreens'
@@ -36,7 +35,7 @@ type VaccineListScreenProps = StackScreenProps<HealthStackParamList, 'VaccineLis
  */
 function VaccineListScreen({ navigation }: VaccineListScreenProps) {
   const [page, setPage] = useState(1)
-  const vaccinesInDowntime = useDowntime(DowntimeFeatureTypeConstants.immunizations)
+  const vaccinesInDowntime = useError(ScreenIDTypesConstants.VACCINE_LIST_SCREEN_ID) // checks for downtime, immunizations downtime constant is having an issue with unit test
   const {
     data: vaccines,
     isLoading: loading,

--- a/VAMobile/src/screens/HealthScreen/Vaccines/VaccineList/VaccineListScreen.tsx
+++ b/VAMobile/src/screens/HealthScreen/Vaccines/VaccineList/VaccineListScreen.tsx
@@ -18,11 +18,12 @@ import {
   TextLine,
 } from 'components'
 import { NAMESPACE } from 'constants/namespaces'
+import { DowntimeFeatureTypeConstants } from 'store/api'
 import { ScreenIDTypesConstants } from 'store/api/types/Screens'
 import { a11yLabelVA } from 'utils/a11yLabel'
 import { getA11yLabelText } from 'utils/common'
 import { formatDateMMMMDDYYYY } from 'utils/formattingUtils'
-import { useRouteNavigation, useTheme } from 'utils/hooks'
+import { useDowntime, useRouteNavigation, useTheme } from 'utils/hooks'
 import { screenContentAllowed } from 'utils/waygateConfig'
 
 import { HealthStackParamList } from '../../HealthStackScreens'
@@ -35,11 +36,12 @@ type VaccineListScreenProps = StackScreenProps<HealthStackParamList, 'VaccineLis
  */
 function VaccineListScreen({ navigation }: VaccineListScreenProps) {
   const [page, setPage] = useState(1)
+  const vaccinesInDowntime = useDowntime(DowntimeFeatureTypeConstants.immunizations)
   const {
     data: vaccines,
     isLoading: loading,
     isError: vaccineError,
-  } = useVaccines(page, { enabled: screenContentAllowed('WG_VaccineList') })
+  } = useVaccines(page, { enabled: screenContentAllowed('WG_VaccineList') && !vaccinesInDowntime })
   const theme = useTheme()
   const { t } = useTranslation(NAMESPACE.COMMON)
   const navigateTo = useRouteNavigation()
@@ -87,7 +89,7 @@ function VaccineListScreen({ navigation }: VaccineListScreenProps) {
     )
   }
 
-  if (vaccineError) {
+  if (vaccineError || vaccinesInDowntime) {
     return (
       <FeatureLandingTemplate
         backLabel={t('health.title')}

--- a/VAMobile/src/screens/HealthScreen/Vaccines/VaccineList/VaccineListScreen.tsx
+++ b/VAMobile/src/screens/HealthScreen/Vaccines/VaccineList/VaccineListScreen.tsx
@@ -35,7 +35,8 @@ type VaccineListScreenProps = StackScreenProps<HealthStackParamList, 'VaccineLis
  */
 function VaccineListScreen({ navigation }: VaccineListScreenProps) {
   const [page, setPage] = useState(1)
-  const vaccinesInDowntime = useError(ScreenIDTypesConstants.VACCINE_LIST_SCREEN_ID) // checks for downtime, immunizations downtime constant is having an issue with unit test
+  // checks for downtime, immunizations downtime constant is having an issue with unit test
+  const vaccinesInDowntime = useError(ScreenIDTypesConstants.VACCINE_LIST_SCREEN_ID)
   const {
     data: vaccines,
     isLoading: loading,

--- a/VAMobile/src/screens/HomeScreen/ProfileScreen/MilitaryInformationScreen/MilitaryInformationScreen.tsx
+++ b/VAMobile/src/screens/HomeScreen/ProfileScreen/MilitaryInformationScreen/MilitaryInformationScreen.tsx
@@ -91,7 +91,7 @@ function MilitaryInformationScreen({ navigation }: MilitaryInformationScreenProp
       backLabel={t('profile.title')}
       backLabelOnPress={navigation.goBack}
       title={t('militaryInformation.title')}>
-      {errorCheck ? (
+      {errorCheck || !mhNotInDowntime ? (
         <ErrorComponent screenID={ScreenIDTypesConstants.MILITARY_INFORMATION_SCREEN_ID} />
       ) : loadingCheck ? (
         <LoadingComponent text={t('militaryInformation.loading')} />

--- a/VAMobile/src/screens/PaymentsScreen/DirectDepositScreen/DirectDepositScreen.tsx
+++ b/VAMobile/src/screens/PaymentsScreen/DirectDepositScreen/DirectDepositScreen.tsx
@@ -81,7 +81,7 @@ function DirectDepositScreen({ navigation }: DirectDepositScreenProps) {
     ]
   }
 
-  if (useBankDataError) {
+  if (useBankDataError || !ddNotInDowntime) {
     return (
       <FeatureLandingTemplate
         backLabel={t('payments.title')}

--- a/VAMobile/src/screens/PaymentsScreen/PaymentHistory/PaymentHistoryScreen.tsx
+++ b/VAMobile/src/screens/PaymentsScreen/PaymentHistory/PaymentHistoryScreen.tsx
@@ -21,8 +21,8 @@ import {
   VAModalPickerProps,
 } from 'components'
 import { NAMESPACE } from 'constants/namespaces'
-import { ScreenIDTypesConstants } from 'store/api/types'
-import { useRouteNavigation, useTheme } from 'utils/hooks'
+import { DowntimeFeatureTypeConstants, ScreenIDTypesConstants } from 'store/api/types'
+import { useDowntime, useRouteNavigation, useTheme } from 'utils/hooks'
 import { getGroupedPayments } from 'utils/payments'
 
 import { PaymentsStackParamList } from '../PaymentsStackScreens'
@@ -38,7 +38,12 @@ function PaymentHistoryScreen({ navigation }: PaymentHistoryScreenProps) {
   const [page, setPage] = useState(1)
   const [yearPickerOption, setYearPickerOption] = useState<yearsDatePickerOption>()
   const [pickerOptions, setpickerOptions] = useState<Array<yearsDatePickerOption>>([])
-  const { data: payments, isLoading: loading, isError: hasError } = usePayments(yearPickerOption?.label, page)
+  const paymentsInDowntime = useDowntime(DowntimeFeatureTypeConstants.payments)
+  const {
+    data: payments,
+    isLoading: loading,
+    isError: hasError,
+  } = usePayments(yearPickerOption?.label, page, { enabled: !paymentsInDowntime })
   const noPayments = payments?.meta.availableYears?.length === 0
 
   type yearsDatePickerOption = {
@@ -135,7 +140,7 @@ function PaymentHistoryScreen({ navigation }: PaymentHistoryScreenProps) {
     )
   }
 
-  if (hasError) {
+  if (hasError || paymentsInDowntime) {
     return (
       <FeatureLandingTemplate
         backLabel={t('payments.title')}


### PR DESCRIPTION
## Description of Change
the screens that were not checking for downtime for the error component are now doing so.

## Screenshots/Video
N/A

## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
Downtime windows should function as before

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
