### PR TITLE
bug/8409-Dylan-FixingDetoxE2EScheduledWorkflow

### DIFF
--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -243,11 +243,15 @@ jobs:
           echo SLACK_THREAD_TS=${ts} >> $GITHUB_OUTPUT
 
       - name: Upload artifacts on failure
-        if: failure()
+        if: steps.run_e2e_tests.outcome == 'failure'
         uses: actions/upload-artifact@v3
         with:
           name: detox-artifacts-${{ runner.os }}-${{ github.run_id }}
           path: VAMobile/artifacts
+
+      - name: Fail workflow if needed(View e2e step for details)
+        if: steps.run_e2e_tests.outcome == 'failure'
+        run: exit 1
 
   matrix-send_test_results_to_testrail:
     if: always() && github.event.inputs.run_testRail == 'true' && github.event.inputs.tests_to_run != ''

--- a/.github/workflows/e2e_ios.yml
+++ b/.github/workflows/e2e_ios.yml
@@ -228,11 +228,15 @@ jobs:
           echo SLACK_THREAD_TS=${ts} >> $GITHUB_OUTPUT
 
       - name: Upload artifacts on failure
-        if: failure()
+        if: steps.run_e2e_tests.outcome == 'failure'
         uses: actions/upload-artifact@v3
         with:
           name: detox-artifacts-${{ runner.os }}-${{ github.run_id }}
           path: VAMobile/artifacts
+
+      - name: Fail workflow if needed(View e2e step for details)
+        if: steps.run_e2e_tests.outcome == 'failure'
+        run: exit 1
 
   matrix-send_test_results_to_testrail:
     if: always() && github.event.inputs.run_testRail == 'true' && github.event.inputs.tests_to_run != ''


### PR DESCRIPTION
## Description of Change
Added same failure check for slack thread to artifact upload and added a workflow failure step so that the workflow is accurately reported as failed if the e2e tests failed.

## Screenshots/Video
N/A

## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
Workflow show accurately fail if e2e tests failed, slack messages should still function correctly

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
