### PR TITLE
Adding alt text to documentation footer logo

### DIFF
--- a/VAMobile/documentation/docusaurus.config.js
+++ b/VAMobile/documentation/docusaurus.config.js
@@ -203,6 +203,7 @@ const config = {
         copyright: `Copyright © ${new Date().getFullYear()} VA Mobile App, Inc. Built with Docusaurus.`,
         logo: {
           src: 'img/va-blue-logo.png',
+          alt: 'VA, United States Department of Veteran Affairs',
         },
       },
 


### PR DESCRIPTION
## Description of Change

The documentation footer didn't have alt text
