### PR TITLE
bug/8525-Dylan-FixedNotificationLinkingSMRQ

### DIFF
--- a/VAMobile/src/constants/linking.tsx
+++ b/VAMobile/src/constants/linking.tsx
@@ -48,7 +48,7 @@ export const linking: LinkingOptions<any> = {
                   state: {
                     routes: [
                       { name: 'Health' },
-                      { name: 'SecureMessaging' },
+                      { name: 'SecureMessaging', params: { activeTab: 0 } },
                       { name: 'ViewMessage', params: { messageID: pathParts[1] } },
                     ],
                   },


### PR DESCRIPTION
## Description of Change
Theo found that notifications would crash cause activeTab wasn't set in the linking cause it was also used in HSP to also navigate correctly

## Screenshots/Video
N/A

## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
Should navigate correctly

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
