### PR TITLE
CU/8368-rachael-detox-clean-up-leaving-app-instance

### DIFF
--- a/VAMobile/e2e/tests/Appeals.e2e.ts
+++ b/VAMobile/e2e/tests/Appeals.e2e.ts
@@ -1,7 +1,7 @@
 import { by, device, element, expect, waitFor } from 'detox'
 import { setTimeout } from 'timers/promises'
 
-import { loginToDemoMode, openBenefits, openClaims, openClaimsHistory } from './utils'
+import { CommonE2eIdConstants, loginToDemoMode, openBenefits, openClaims, openClaimsHistory } from './utils'
 
 export const AppealsIdConstants = {
   APPEAL_1_ID: 'Disability compensation appeal updated on November 22, 2011 Received June 12, 2008',
@@ -98,7 +98,7 @@ describe('Appeals', () => {
     await device.launchApp({ newInstance: false })
     await device.disableSynchronization()
     await element(by.text(AppealsIdConstants.APPEAL_VISIT_VA_TEXT)).tap()
-    await element(by.text('Leave')).tap()
+    await element(by.text(CommonE2eIdConstants.LEAVING_APP_LEAVE_TEXT)).tap()
     await setTimeout(5000)
     await device.takeScreenshot('AppealsNeedHelpGoToVAScreen')
     await device.enableSynchronization()

--- a/VAMobile/e2e/tests/Cerner.e2e.ts
+++ b/VAMobile/e2e/tests/Cerner.e2e.ts
@@ -1,7 +1,7 @@
 import { by, device, element, expect } from 'detox'
 import { setTimeout } from 'timers/promises'
 
-import { loginToDemoMode, openAppointments, openHealth, openMessages } from './utils'
+import { CommonE2eIdConstants, loginToDemoMode, openAppointments, openHealth, openMessages } from './utils'
 
 export const CernerIdConstants = {
   GO_TO_VA_HEALTH_LINK_ID: 'goToMyVAHealthTestID',
@@ -35,7 +35,7 @@ describe(':android: Cerner Notice', () => {
   it('verify the correct webpage My Health link is opened', async () => {
     await element(by.id(CernerIdConstants.HEALTH_CATEGORY_ID)).scrollTo('bottom')
     await element(by.id(CernerIdConstants.GO_TO_VA_HEALTH_LINK_ID)).tap()
-    await element(by.text('Leave')).tap()
+    await element(by.text(CommonE2eIdConstants.LEAVING_APP_LEAVE_TEXT)).tap()
     await setTimeout(5000)
     await device.takeScreenshot('cernerVAHealthLink')
     await device.launchApp({ newInstance: false })

--- a/VAMobile/e2e/tests/Claims.e2e.ts
+++ b/VAMobile/e2e/tests/Claims.e2e.ts
@@ -90,7 +90,7 @@ describe('Claims Screen', () => {
       element(by.label('What should I do if I disagree with your decision on my  V-A  disability claim?')),
     ).toExist()
     await element(by.id('ClaimsDecisionReviewOptionsTestID')).tap()
-    await element(by.text('Leave')).tap()
+    await element(by.text(CommonE2eIdConstants.LEAVING_APP_LEAVE_TEXT)).tap()
     await setTimeout(5000)
     await device.takeScreenshot('DecisionReviewOptionsWebsite')
     await device.launchApp({ newInstance: false })

--- a/VAMobile/e2e/tests/DisabilityRatings.e2e.ts
+++ b/VAMobile/e2e/tests/DisabilityRatings.e2e.ts
@@ -1,7 +1,7 @@
 import { by, device, element, expect } from 'detox'
 import { setTimeout } from 'timers/promises'
 
-import { loginToDemoMode, openBenefits, openDisabilityRating } from './utils'
+import { CommonE2eIdConstants, loginToDemoMode, openBenefits, openDisabilityRating } from './utils'
 
 export const DisabilityRatingsIdConstants = {
   COMBINED_DISABILITY_RATING_TEXT: 'Combined disability rating',
@@ -34,7 +34,7 @@ describe('Disability Ratings', () => {
   it('verify About VA disability ratings information', async () => {
     await element(by.id(DisabilityRatingsIdConstants.DISABILITY_RATING_PAGE_ID)).scrollTo('bottom')
     await element(by.id(DisabilityRatingsIdConstants.ABOUT_DISABILITY_RATINGS_LINK_ID)).tap()
-    await element(by.text('Leave')).tap()
+    await element(by.text(CommonE2eIdConstants.LEAVING_APP_LEAVE_TEXT)).tap()
     await setTimeout(5000)
     await device.takeScreenshot('AboutDisabilityRatings')
     await device.launchApp({ newInstance: false })

--- a/VAMobile/e2e/tests/Letters.e2e.ts
+++ b/VAMobile/e2e/tests/Letters.e2e.ts
@@ -2,6 +2,7 @@ import { by, device, element, expect } from 'detox'
 import { setTimeout } from 'timers/promises'
 
 import {
+  CommonE2eIdConstants,
   checkIfElementIsPresent,
   loginToDemoMode,
   openBenefits,
@@ -129,7 +130,7 @@ describe('VA Letters', () => {
         if (isBenefitSummaryLetter) {
           await element(by.id('BenefitSummaryServiceVerificationTestID')).scrollTo('bottom')
           await element(by.text('Go to Ask VA')).tap()
-          await element(by.text('Leave')).tap()
+          await element(by.text(CommonE2eIdConstants.LEAVING_APP_LEAVE_TEXT)).tap()
           await setTimeout(2000)
           await device.takeScreenshot('benefitSummaryLetterAskVAWebpage')
           await device.launchApp({ newInstance: false })

--- a/VAMobile/e2e/tests/Messages.e2e.ts
+++ b/VAMobile/e2e/tests/Messages.e2e.ts
@@ -2,7 +2,7 @@ import { by, device, element, expect, waitFor } from 'detox'
 import { DateTime } from 'luxon'
 import { setTimeout } from 'timers/promises'
 
-import { checkImages, loginToDemoMode, openHealth, openMessages, resetInAppReview } from './utils'
+import { CommonE2eIdConstants, checkImages, loginToDemoMode, openHealth, openMessages, resetInAppReview } from './utils'
 
 export async function getDateWithTimeZone(dateString: string) {
   const date = DateTime.fromFormat(dateString, 'LLLL d, yyyy h:m a', { zone: 'America/Chicago' })
@@ -53,7 +53,6 @@ export const MessagesE2eIdConstants = {
   EDIT_DRAFT_CANCEL_ID: 'editDraftCancelTestID',
   EDIT_DRAFT_CANCEL_DELETE_TEXT: device.getPlatform() === 'ios' ? 'Delete Changes' : 'Delete Changes ',
   EDIT_DRAFT_CANCEL_SAVE_TEXT: device.getPlatform() === 'ios' ? 'Save Changes' : 'Save Changes ',
-  OPEN_URL_TEXT: 'Leave',
 }
 
 const tapItems = async (items: string, type: string) => {
@@ -62,7 +61,7 @@ const tapItems = async (items: string, type: string) => {
   }
   await element(by.text(items)).tap()
   if (type === 'url' || type === 'map') {
-    await element(by.text(MessagesE2eIdConstants.OPEN_URL_TEXT)).tap()
+    await element(by.text(CommonE2eIdConstants.LEAVING_APP_LEAVE_TEXT)).tap()
   }
   await setTimeout(2000)
   await device.takeScreenshot(items)
@@ -379,7 +378,7 @@ describe('Messages Screen', () => {
     await device.launchApp({ newInstance: false })
 
     await element(by.text('Start a confidential chat')).tap()
-    await element(by.text('Leave')).tap()
+    await element(by.text(CommonE2eIdConstants.LEAVING_APP_LEAVE_TEXT)).tap()
     await setTimeout(5000)
     await device.takeScreenshot('messagesHelpChat')
     await device.launchApp({ newInstance: false })

--- a/VAMobile/e2e/tests/PersonalInformationScreen.e2e.ts
+++ b/VAMobile/e2e/tests/PersonalInformationScreen.e2e.ts
@@ -1,7 +1,7 @@
 import { by, device, element, expect, waitFor } from 'detox'
 import { setTimeout } from 'timers/promises'
 
-import { loginToDemoMode, openPersonalInformation, openProfile } from './utils'
+import { CommonE2eIdConstants, loginToDemoMode, openPersonalInformation, openProfile } from './utils'
 
 export const PersonalInfoConstants = {
   PERSONAL_INFORMATION_TEXT: 'Personal information',
@@ -89,7 +89,7 @@ describe('Personal Info Screen', () => {
     await expect(element(by.text('Profile help'))).toExist()
 
     await element(by.text(PersonalInfoConstants.LEARN_HOW_LINK_TEXT)).tap()
-    await element(by.text('Leave')).tap()
+    await element(by.text(CommonE2eIdConstants.LEAVING_APP_LEAVE_TEXT)).tap()
     await setTimeout(5000)
     await device.takeScreenshot('personalInfoLearnHowToWebPage')
     await device.launchApp({ newInstance: false })

--- a/VAMobile/e2e/tests/Prescriptions.e2e.ts
+++ b/VAMobile/e2e/tests/Prescriptions.e2e.ts
@@ -1,7 +1,14 @@
 import { by, device, element, expect, waitFor } from 'detox'
 import { setTimeout } from 'timers/promises'
 
-import { changeMockData, checkImages, loginToDemoMode, openHealth, openPrescriptions } from './utils'
+import {
+  CommonE2eIdConstants,
+  changeMockData,
+  checkImages,
+  loginToDemoMode,
+  openHealth,
+  openPrescriptions,
+} from './utils'
 
 export const PrescriptionsE2eIdConstants = {
   PRESCRIPTION_REFILL_BUTTON_TEXT: 'Start refill request',
@@ -151,7 +158,7 @@ describe('Prescriptions Screen', () => {
     ).toExist()
     await expect(element(by.label('Go to My  V-A  Health')).atIndex(trackingIndex)).toExist()
     await element(by.label('Go to My  V-A  Health')).atIndex(trackingIndex).tap()
-    await element(by.text('Leave')).tap()
+    await element(by.text(CommonE2eIdConstants.LEAVING_APP_LEAVE_TEXT)).tap()
     await setTimeout(5000)
     await device.takeScreenshot('PrescriptionVAHealthLink')
     await device.launchApp({ newInstance: false })
@@ -270,7 +277,7 @@ describe('Prescriptions Screen', () => {
 
   it('verify tracking link for DHL works', async () => {
     await element(by.label('7 5 3 4 5 3 3 6 3 6 8 5 6')).atIndex(trackingIndex).tap()
-    await element(by.text('Leave')).tap()
+    await element(by.text(CommonE2eIdConstants.LEAVING_APP_LEAVE_TEXT)).tap()
     await setTimeout(5000)
     await device.takeScreenshot('PrescriptionTrackingWebsiteDHL')
     await device.launchApp({ newInstance: false })
@@ -285,7 +292,7 @@ describe('Prescriptions Screen', () => {
     await element(by.text(PrescriptionsE2eIdConstants.PRESCRIPTION_TRACKING_GET_TRACKING_TEXT)).atIndex(1).tap()
     await expect(element(by.text('Delivery service: FEDEX'))).toExist()
     await element(by.label('7 5 3 4 5 3 3 6 3 6 8 5 6')).atIndex(trackingIndex).tap()
-    await element(by.text('Leave')).tap()
+    await element(by.text(CommonE2eIdConstants.LEAVING_APP_LEAVE_TEXT)).tap()
     await setTimeout(5000)
     await device.takeScreenshot('PrescriptionTrackingWebsiteFedex')
     await device.launchApp({ newInstance: false })
@@ -306,7 +313,7 @@ describe('Prescriptions Screen', () => {
 
   it(':android: verify tracking link for UPS works', async () => {
     await element(by.label('7 7 2 9 8 0 2 7 2 0 3 9 8 0 0 0 0 0 0 0 3 9 8')).atIndex(trackingIndex).tap()
-    await element(by.text('Leave')).tap()
+    await element(by.text(CommonE2eIdConstants.LEAVING_APP_LEAVE_TEXT)).tap()
     await setTimeout(5000)
     await device.takeScreenshot('PrescriptionTrackingWebsiteUPS')
     await device.launchApp({ newInstance: true, permissions: { location: 'always' } })
@@ -323,7 +330,7 @@ describe('Prescriptions Screen', () => {
   it('verify tracking link for USPS works', async () => {
     await element(by.id('refillTrackingDetailsTestID')).scrollTo('bottom')
     await element(by.label('9 2 0 5   5 0 0 0   0 0 0 0   0 0 0 0   0 0 0 0   0 0')).atIndex(trackingIndex).tap()
-    await element(by.text('Leave')).tap()
+    await element(by.text(CommonE2eIdConstants.LEAVING_APP_LEAVE_TEXT)).tap()
     await setTimeout(5000)
     await device.takeScreenshot('PrescriptionTrackingWebsiteUSPS')
     await device.launchApp({ newInstance: false })

--- a/VAMobile/e2e/tests/SettingsScreen.e2e.ts
+++ b/VAMobile/e2e/tests/SettingsScreen.e2e.ts
@@ -104,7 +104,7 @@ describe('Settings Screen', () => {
 
   it('should show Privacy Policy page', async () => {
     await element(by.text(SettingsE2eIdConstants.PRIVACY_ROW_TEXT)).tap()
-    await element(by.text('Leave')).tap()
+    await element(by.text(CommonE2eIdConstants.LEAVING_APP_LEAVE_TEXT)).tap()
     await setTimeout(5000)
     await device.takeScreenshot('SettingsPrivacyPolicy')
     await device.launchApp({ newInstance: false })

--- a/VAMobile/e2e/tests/VeteransCrisisLine.e2e.ts
+++ b/VAMobile/e2e/tests/VeteransCrisisLine.e2e.ts
@@ -1,7 +1,9 @@
+import { Commands } from 'react-native-webview/lib/RNCWebViewNativeComponent'
+
 import { by, device, element, expect } from 'detox'
 import { setTimeout } from 'timers/promises'
 
-import { loginToDemoMode, openVeteransCrisisLine } from './utils'
+import { CommonE2eIdConstants, loginToDemoMode, openVeteransCrisisLine } from './utils'
 
 export const VCLConstants = {
   HEADING_TEXT: 'Veterans Crisis Line',
@@ -53,7 +55,7 @@ describe('Veterans Crisis Line', () => {
 
   it('should open chat link', async () => {
     await element(by.text(VCLConstants.CHAT_LINK_TEXT)).tap()
-    await element(by.text('Leave')).tap()
+    await element(by.text(CommonE2eIdConstants.LEAVING_APP_LEAVE_TEXT)).tap()
     await setTimeout(5000)
     await device.takeScreenshot('CrisisLineChat')
     await device.launchApp({ newInstance: false })
@@ -61,7 +63,7 @@ describe('Veterans Crisis Line', () => {
 
   it('should open website link', async () => {
     await element(by.text(VCLConstants.VCL_SITE_LINK_TEXT)).tap()
-    await element(by.text('Leave')).tap()
+    await element(by.text(CommonE2eIdConstants.LEAVING_APP_LEAVE_TEXT)).tap()
     await setTimeout(5000)
     await device.takeScreenshot('VCLWebsite')
     await device.launchApp({ newInstance: false })


### PR DESCRIPTION
## Description of Change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, 
need to know about this PR in order to understand why this PR was created? This could include dependencies 
introduced, changes in behavior, pointers to more detailed documentation. The description should be more 
than a link to an issue.  -->
Change instances of 'Leave' to the CommonE2eIdConstants.LEAVING_APP_LEAVE_TEXT in all scripts.

## Screenshots/Video
<!-- Add screenshots or video as needed. Before/after if changes are to be compared by reviewers.
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Toggle: <details><summary></summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>
-->

## Testing
<!-- What testing was done to verify the changes (local/unit)? What testing remains? Note edge cases, or special
situations that could not be tested during development. -->

- [ ] Tested on iOS <!-- simulator is fine -->
- [ ] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
<!-- What should reviewers look for? Copy/paste Acceptance Criteria from ticket -->

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [ ] PR is connected to issue(s)
- [ ] Tests are included to cover this change (when possible)
- [ ] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [ ] No secrets or API keys are checked in
- [ ] All imports are absolute (no relative imports)
- [ ] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
