### PR TITLE
bug/8584-theo-RQCacheBust

### DIFF
--- a/VAMobile/src/api/appointments/getAppointments.tsx
+++ b/VAMobile/src/api/appointments/getAppointments.tsx
@@ -27,6 +27,7 @@ const getAppointments = (
     'page[size]': DEFAULT_PAGE_SIZE.toString(),
     sort: `${timeFrame !== TimeFrameTypeConstants.UPCOMING ? '-' : ''}startDateUtc`, // reverse sort for past timeRanges so it shows most recent to oldest
     'included[]': 'pending',
+    useCache: 'false',
   } as Params)
 }
 

--- a/VAMobile/src/api/claimsAndAppeals/getClaimsAndAppeals.tsx
+++ b/VAMobile/src/api/claimsAndAppeals/getClaimsAndAppeals.tsx
@@ -30,6 +30,7 @@ const getClaimsAndAppeals = async (
     'page[number]': page.toString(),
     'page[size]': DEFAULT_PAGE_SIZE.toString(),
     showCompleted: claimType === ClaimTypeConstants.ACTIVE ? 'false' : 'true',
+    useCache: 'false',
   })
 
   if (response) {

--- a/VAMobile/src/api/queryClient.ts
+++ b/VAMobile/src/api/queryClient.ts
@@ -6,6 +6,7 @@ import { isErrorObject } from 'utils/common'
 export default new QueryClient({
   defaultOptions: {
     queries: {
+      retry: false,
       staleTime: 5000,
     },
   },

--- a/VAMobile/src/api/secureMessaging/getFolderMessages.tsx
+++ b/VAMobile/src/api/secureMessaging/getFolderMessages.tsx
@@ -16,6 +16,7 @@ const getFolderMessages = (
   return get<SecureMessagingFolderMessagesGetData>(`/v0/messaging/health/folders/${folderID}/messages`, {
     page: page.toString(),
     per_page: DEFAULT_PAGE_SIZE.toString(),
+    useCache: 'false',
   } as Params)
 }
 

--- a/VAMobile/src/api/secureMessaging/getFolders.tsx
+++ b/VAMobile/src/api/secureMessaging/getFolders.tsx
@@ -15,7 +15,9 @@ import { secureMessagingKeys } from './queryKeys'
  * Fetch user folders
  */
 const getFolders = async (): Promise<SecureMessagingFoldersGetData | undefined> => {
-  const response = await get<SecureMessagingFoldersGetData>('/v0/messaging/health/folders')
+  const response = await get<SecureMessagingFoldersGetData>('/v0/messaging/health/folders', {
+    useCache: 'false',
+  })
   if (response) {
     return {
       ...response,

--- a/VAMobile/src/api/vaccines/getVaccines.tsx
+++ b/VAMobile/src/api/vaccines/getVaccines.tsx
@@ -14,6 +14,7 @@ const getVaccines = (page: number): Promise<VaccineListPayload | undefined> => {
     'page[number]': page.toString(),
     'page[size]': DEFAULT_PAGE_SIZE.toString(),
     sort: 'date',
+    useCache: 'false',
   })
 }
 


### PR DESCRIPTION
## Description of Change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, 
need to know about this PR in order to understand why this PR was created? This could include dependencies 
introduced, changes in behavior, pointers to more detailed documentation. The description should be more 
than a link to an issue.  -->
Disables query retries globally and busts the backend cache for the following queries:
- Vaccines
- Appointments
- Claims and appeals
- Folder messages

## Screenshots/Video
<!-- Add screenshots or video as needed. Before/after if changes are to be compared by reviewers.
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Toggle: <details><summary></summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>
-->
N/A

## Testing
<!-- What testing was done to verify the changes (local/unit)? What testing remains? Note edge cases, or special
situations that could not be tested during development. -->

- [ ] Tested on iOS <!-- simulator is fine -->
- [ ] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
<!-- What should reviewers look for? Copy/paste Acceptance Criteria from ticket -->

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [ ] PR is connected to issue(s)
- [ ] Tests are included to cover this change (when possible)
- [ ] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [ ] No secrets or API keys are checked in
- [ ] All imports are absolute (no relative imports)
- [ ] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
