### PR TITLE
fixed

### DIFF
--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/ViewMessage/ViewMessageScreen.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/ViewMessage/ViewMessageScreen.tsx
@@ -155,19 +155,16 @@ function ViewMessageScreen({ route, navigation }: ViewMessageScreenProps) {
   }, [threadFetched])
 
   useEffect(() => {
-    if (
-      messageFetched &&
-      currentFolderIdParam === SecureMessagingSystemFolderIdConstants.INBOX &&
-      messageData?.data.attributes.readReceipt !== READ &&
-      currentPage
-    ) {
+    if (messageFetched && currentFolderIdParam === SecureMessagingSystemFolderIdConstants.INBOX && currentPage) {
+      let updateQueries = false
       const inboxMessagesData = queryClient.getQueryData([
         secureMessagingKeys.folderMessages,
         currentFolderIdParam,
         currentPage,
       ]) as SecureMessagingFolderMessagesGetData
       const newInboxMessages = inboxMessagesData.data.map((m) => {
-        if (m.attributes.messageId === message.messageId) {
+        if (m.attributes.messageId === message.messageId && m.attributes.readReceipt !== READ) {
+          updateQueries = true
           m.attributes.readReceipt = READ
           const oldMessageAttributes = messageData?.data.attributes || ({} as SecureMessagingMessageAttributes)
           oldMessageAttributes.readReceipt = READ
@@ -181,22 +178,24 @@ function ViewMessageScreen({ route, navigation }: ViewMessageScreenProps) {
         }
         return m
       })
-      const newData = { ...inboxMessagesData, data: newInboxMessages } as SecureMessagingFolderMessagesGetData
-      queryClient.setQueryData([secureMessagingKeys.folderMessages, currentFolderIdParam, currentPage], newData)
-      if (foldersData) {
-        let inboxUnreadCount = foldersData.inboxUnreadCount
-        const newFolders = foldersData.data.map((folder) => {
-          if (folder.attributes.name === FolderNameTypeConstants.inbox) {
-            folder.attributes.unreadCount = folder.attributes.unreadCount - 1
-            inboxUnreadCount = folder.attributes.unreadCount
-          }
-          return folder
-        }) as SecureMessagingFolderList
-        queryClient.setQueryData(secureMessagingKeys.folders, {
-          ...foldersData,
-          data: newFolders,
-          inboxUnreadCount,
-        } as SecureMessagingFoldersGetData)
+      if (updateQueries) {
+        const newData = { ...inboxMessagesData, data: newInboxMessages } as SecureMessagingFolderMessagesGetData
+        queryClient.setQueryData([secureMessagingKeys.folderMessages, currentFolderIdParam, currentPage], newData)
+        if (foldersData) {
+          let inboxUnreadCount = foldersData.inboxUnreadCount
+          const newFolders = foldersData.data.map((folder) => {
+            if (folder.attributes.name === FolderNameTypeConstants.inbox) {
+              folder.attributes.unreadCount = folder.attributes.unreadCount - 1
+              inboxUnreadCount = folder.attributes.unreadCount
+            }
+            return folder
+          }) as SecureMessagingFolderList
+          queryClient.setQueryData(secureMessagingKeys.folders, {
+            ...foldersData,
+            data: newFolders,
+            inboxUnreadCount,
+          } as SecureMessagingFoldersGetData)
+        }
       }
     }
   }, [


### PR DESCRIPTION
## Description of Change
Found that the read receipt wasn't being manually set and was being refreshed because of stale time, updated the code to look at the read receipt in the folder messages instead of the individual message data and therefore making it instant and no longer reliant on the stale time.

## Screenshots/Video
N/A

## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
Fix this scenario - before the data is sync'd you navigate to another unread message. This then causes a sync issue and then results in the 2nd message being marked as unread. 

This was caused due to the staleTime being refreshed.

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
