### PR TITLE
bug/8689-Dylan-EditDraftReplySendMessageFix

### DIFF
--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/EditDraft/EditDraft.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/EditDraft/EditDraft.tsx
@@ -502,7 +502,7 @@ function EditDraft({ navigation, route }: EditDraftProps) {
           })
         },
       }
-      const params: SendMessageParameters = { messageData: messageData, uploads: attachmentsList }
+      const params: SendMessageParameters = { messageData: messageData, uploads: attachmentsList, replyToID: replyToID }
       sendMessage(params, mutateOptions)
     }
   }


### PR DESCRIPTION
## Description of Change
When in the edit draft screen if you were trying to send a message that was a reply it wasn't working. This pr fixes this by correctly calling the right end point.

## Screenshots/Video
N/A

## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
Should be able to send messages from edit draft screen

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
