### PR TITLE
bug/8535-Dylan-WhatsNewDocumentationImprovement

### DIFF
--- a/VAMobile/documentation/docs/App Features/EncouragedUpdate/EncouragedUpdate.md
+++ b/VAMobile/documentation/docs/App Features/EncouragedUpdate/EncouragedUpdate.md
@@ -12,7 +12,7 @@ This is potentially a precursor to forced upgrading in the future after so many 
 * Use Case 2: The version on the device is older than what is in the store, and the veteran decided to skip the encourage update for this version so it does not display the alert
 * Use Case 3: The version on the device is the same version in the store or newer (updates from the app store roll out to devices periodically, so it is possible that the app was updated but the store's API is returning an older version) so it displays the [What's New](../WhatsNew/WhatsNew.md) alert if applicable 
 
-## How to force this to apper in Demo Mode
+## How to force this to appear in Demo Mode
 Step 1: Go to the developer screen in the settings part of the app and scroll to the bottom where it has Encouraged Update and What's New versions
 Step 2: Set the Encouraged Update version override to a version that is lower than the store version
 Step 3: logout of the app and log back into demo mode

--- a/VAMobile/documentation/docs/App Features/EncouragedUpdate/EncouragedUpdate.md
+++ b/VAMobile/documentation/docs/App Features/EncouragedUpdate/EncouragedUpdate.md
@@ -15,7 +15,7 @@ This is potentially a precursor to forced upgrading in the future after so many 
 ## How to force this to appear in Demo Mode
 Step 1: Go to the developer screen in the settings part of the app and scroll to the bottom where it has Encouraged Update and What's New versions
 Step 2: Set the Encouraged Update version override to a version that is lower than the store version
-Step 3: logout of the app and log back into demo mode
+Step 3: Logout of the app and log back into demo mode
 
 ## Screenshot
 

--- a/VAMobile/documentation/docs/App Features/EncouragedUpdate/EncouragedUpdate.md
+++ b/VAMobile/documentation/docs/App Features/EncouragedUpdate/EncouragedUpdate.md
@@ -12,6 +12,11 @@ This is potentially a precursor to forced upgrading in the future after so many 
 * Use Case 2: The version on the device is older than what is in the store, and the veteran decided to skip the encourage update for this version so it does not display the alert
 * Use Case 3: The version on the device is the same version in the store or newer (updates from the app store roll out to devices periodically, so it is possible that the app was updated but the store's API is returning an older version) so it displays the [What's New](../WhatsNew/WhatsNew.md) alert if applicable 
 
+## How to force this to apper in Demo Mode
+Step 1: Go to the developer screen in the settings part of the app and scroll to the bottom where it has Encouraged Update and What's New versions
+Step 2: Set the Encouraged Update version override to a version that is lower than the store version
+Step 3: logout of the app and log back into demo mode
+
 ## Screenshot
 
 ![](../../../static/img/encouragedUpdate/EncouragedUpdate.png)

--- a/VAMobile/documentation/docs/App Features/WhatsNew/WhatsNew.md
+++ b/VAMobile/documentation/docs/App Features/WhatsNew/WhatsNew.md
@@ -11,6 +11,12 @@ What's new displays to the veteran what is new in the version that they upgraded
 * Use Case 3: The user is on a older version of the app and instead sees [Encouraged Update](../EncouragedUpdate/EncouragedUpdate.md)
 * Use Case 4: The user is on the most recent version, but there are no notes to be displayed, so there is no alert
 
+## How to force this to apper in Demo Mode
+Step 1: Go to the developer screen in the settings part of the app and scroll to the bottom where it has Encouraged Update and What's New versions
+Step 2: Set the Encouraged Update version override to a version that is equal to or greater than the store version
+Step 3: Set the What's New version override to a version that is a valid version in the common.json file in the translations folder (Valid version at the time of writing this are 2.0, 2.2, 2.3, 2.13, and 2.23)
+Step 4: logout of the app and log back into demo mode
+
 ## Example Screenshot
 
 Expanded: ![](../../../static/img/whatsNew/WhatsNewExpanded.png)

--- a/VAMobile/documentation/docs/App Features/WhatsNew/WhatsNew.md
+++ b/VAMobile/documentation/docs/App Features/WhatsNew/WhatsNew.md
@@ -15,7 +15,7 @@ What's new displays to the veteran what is new in the version that they upgraded
 Step 1: Go to the developer screen in the settings part of the app and scroll to the bottom where it has Encouraged Update and What's New versions
 Step 2: Set the Encouraged Update version override to a version that is equal to or greater than the store version
 Step 3: Set the What's New version override to a version that is a valid version in the `common.json` file in the translations folder (Valid versions at the time of writing this are 2.0, 2.2, 2.3, 2.13, and 2.23)
-Step 4: logout of the app and log back into demo mode
+Step 4: Logout of the app and log back into demo mode
 
 ## Example Screenshot
 

--- a/VAMobile/documentation/docs/App Features/WhatsNew/WhatsNew.md
+++ b/VAMobile/documentation/docs/App Features/WhatsNew/WhatsNew.md
@@ -11,7 +11,7 @@ What's new displays to the veteran what is new in the version that they upgraded
 * Use Case 3: The user is on a older version of the app and instead sees [Encouraged Update](../EncouragedUpdate/EncouragedUpdate.md)
 * Use Case 4: The user is on the most recent version, but there are no notes to be displayed, so there is no alert
 
-## How to force this to apper in Demo Mode
+## How to force this to appear in Demo Mode
 Step 1: Go to the developer screen in the settings part of the app and scroll to the bottom where it has Encouraged Update and What's New versions
 Step 2: Set the Encouraged Update version override to a version that is equal to or greater than the store version
 Step 3: Set the What's New version override to a version that is a valid version in the common.json file in the translations folder (Valid version at the time of writing this are 2.0, 2.2, 2.3, 2.13, and 2.23)

--- a/VAMobile/documentation/docs/App Features/WhatsNew/WhatsNew.md
+++ b/VAMobile/documentation/docs/App Features/WhatsNew/WhatsNew.md
@@ -14,7 +14,7 @@ What's new displays to the veteran what is new in the version that they upgraded
 ## How to force this to appear in Demo Mode
 Step 1: Go to the developer screen in the settings part of the app and scroll to the bottom where it has Encouraged Update and What's New versions
 Step 2: Set the Encouraged Update version override to a version that is equal to or greater than the store version
-Step 3: Set the What's New version override to a version that is a valid version in the common.json file in the translations folder (Valid version at the time of writing this are 2.0, 2.2, 2.3, 2.13, and 2.23)
+Step 3: Set the What's New version override to a version that is a valid version in the `common.json` file in the translations folder (Valid versions at the time of writing this are 2.0, 2.2, 2.3, 2.13, and 2.23)
 Step 4: logout of the app and log back into demo mode
 
 ## Example Screenshot


### PR DESCRIPTION
## Description of Change
Just added demo mode instructions to the feature documentation on how to get them to display.

## Screenshots/Video
N/A

## Testing
N/A

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
 spent a good chunk of time this morning trying to get What's New to show up, with little success. We should have standard documentation about this, somewhere, to prevent this in the future.

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
