### PR TITLE
bug/8691-Dylan-SendEditDraftRefresh

### DIFF
--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/EditDraft/EditDraft.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/EditDraft/EditDraft.tsx
@@ -495,11 +495,10 @@ function EditDraft({ navigation, route }: EditDraftProps) {
         onSuccess: () => {
           showSnackBar(snackbarSentMessages.successMsg, dispatch, undefined, true, false, true)
           logAnalyticsEvent(Events.vama_sm_send_message(messageData.category, undefined))
-          navigateTo('FolderMessages', {
-            folderID: SecureMessagingSystemFolderIdConstants.DRAFTS,
-            folderName: FolderNameTypeConstants.drafts,
-            draftSaved: false,
+          queryClient.invalidateQueries({
+            queryKey: [secureMessagingKeys.folderMessages, SecureMessagingSystemFolderIdConstants.DRAFTS, 1],
           })
+          goToDraftFolder(false)
         },
       }
       const params: SendMessageParameters = { messageData: messageData, uploads: attachmentsList, replyToID: replyToID }

--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/FolderMessages/FolderMessages.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/FolderMessages/FolderMessages.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ScrollView } from 'react-native'
 
+import { useIsFocused } from '@react-navigation/native'
 import { StackScreenProps } from '@react-navigation/stack/lib/typescript/src/types'
 
 import { Button } from '@department-of-veterans-affairs/mobile-component-library'
@@ -38,13 +39,14 @@ function FolderMessages({ route }: FolderMessagesProps) {
   const theme = useTheme()
   const navigateTo = useRouteNavigation()
   const [page, setPage] = useState(1)
+  const isFocused = useIsFocused()
   const {
     data: folderMessagesData,
     isFetching: loadingFolderMessages,
     error: folderMessagesError,
     refetch: refetchFolderMessages,
   } = useFolderMessages(folderID, page, {
-    enabled: screenContentAllowed('WG_FolderMessages'),
+    enabled: isFocused && screenContentAllowed('WG_FolderMessages'),
   })
   const messages = folderMessagesData?.data || ([] as SecureMessagingMessageList)
   const paginationMetaData = folderMessagesData?.meta.pagination


### PR DESCRIPTION
## Description of Change
Added a refetch of the data from the BE after a user sends a message from the edit draft screen

## Screenshots/Video
N/A

## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
Messages should not appear in the list view once sent

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
