### PR TITLE
bug/7406-Dylan-AFUseCase2UploadPhotoFileBeforeBackNavPopupFix

### DIFF
--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/SelectFile/UploadFile/UploadFile.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/SelectFile/UploadFile/UploadFile.tsx
@@ -53,7 +53,7 @@ function UploadFile({ navigation, route }: UploadFileProps) {
   const waygate = getWaygateToggles().WG_UploadFile
 
   useBeforeNavBackListener(navigation, (e) => {
-    if (filesList?.length === 0 || filesUploadedSuccess || !waygate.enabled) {
+    if (filesList?.length === 0 || filesUploadedSuccess || (!waygate.enabled && waygate.type === 'DenyContent')) {
       return
     }
     e.preventDefault()

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/SelectFile/UploadFile/UploadFile.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/SelectFile/UploadFile/UploadFile.tsx
@@ -25,6 +25,7 @@ import {
   useRouteNavigation,
   useTheme,
 } from 'utils/hooks'
+import { getWaygateToggles } from 'utils/waygateConfig'
 
 type UploadFileProps = StackScreenProps<BenefitsStackParamList, 'UploadFile'>
 
@@ -49,8 +50,10 @@ function UploadFile({ navigation, route }: UploadFileProps) {
     errorMsg: t('fileUpload.submitted.error'),
   }
 
+  const waygate = getWaygateToggles().WG_UploadFile
+
   useBeforeNavBackListener(navigation, (e) => {
-    if (filesList?.length === 0 || filesUploadedSuccess) {
+    if (filesList?.length === 0 || filesUploadedSuccess || !waygate.enabled) {
       return
     }
     e.preventDefault()

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/TakePhotos/UploadOrAddPhotos/UploadOrAddPhotos.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/TakePhotos/UploadOrAddPhotos/UploadOrAddPhotos.tsx
@@ -42,6 +42,7 @@ import {
   useShowActionSheet,
   useTheme,
 } from 'utils/hooks'
+import { getWaygateToggles } from 'utils/waygateConfig'
 
 type UploadOrAddPhotosProps = StackScreenProps<BenefitsStackParamList, 'UploadOrAddPhotos'>
 
@@ -73,8 +74,10 @@ function UploadOrAddPhotos({ navigation, route }: UploadOrAddPhotosProps) {
     errorMsg: t('fileUpload.submitted.error'),
   }
 
+  const waygate = getWaygateToggles().WG_UploadOrAddPhotos
+
   useBeforeNavBackListener(navigation, (e) => {
-    if (imagesList?.length === 0 || filesUploadedSuccess) {
+    if (imagesList?.length === 0 || filesUploadedSuccess || !waygate.enabled) {
       return
     }
     e.preventDefault()

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/TakePhotos/UploadOrAddPhotos/UploadOrAddPhotos.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/TakePhotos/UploadOrAddPhotos/UploadOrAddPhotos.tsx
@@ -77,7 +77,7 @@ function UploadOrAddPhotos({ navigation, route }: UploadOrAddPhotosProps) {
   const waygate = getWaygateToggles().WG_UploadOrAddPhotos
 
   useBeforeNavBackListener(navigation, (e) => {
-    if (imagesList?.length === 0 || filesUploadedSuccess || !waygate.enabled) {
+    if (imagesList?.length === 0 || filesUploadedSuccess || (!waygate.enabled && waygate.type === 'DenyContent')) {
       return
     }
     e.preventDefault()


### PR DESCRIPTION
## Description of Change
Removed the popup that occurred for AF use case 2 on the upload file/photos screens in claims.

## Screenshots/Video

https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/38cca256-ccb8-44c0-a1b7-a5624cf271f3

## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
not show that cancellation banner specifically when AF UC2 is in play

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
