### PR TITLE
bug/8744-Dylan-ChangeStaleTimeMessageThreads

### DIFF
--- a/VAMobile/src/api/secureMessaging/getThread.tsx
+++ b/VAMobile/src/api/secureMessaging/getThread.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 
 import { SecureMessagingThreadGetData } from 'api/types'
-import { get } from 'store/api'
+import { Params, get } from 'store/api'
 
 import { secureMessagingKeys } from './queryKeys'
 
@@ -14,6 +14,9 @@ const getThread = (
 ): Promise<SecureMessagingThreadGetData | undefined> => {
   return get<SecureMessagingThreadGetData>(
     `/v1/messaging/health/messages/${messageID}/thread?excludeProvidedMessage=${excludeProvidedMessage}`,
+    {
+      useCache: 'false',
+    } as Params,
   )
 }
 

--- a/VAMobile/src/api/secureMessaging/getThread.tsx
+++ b/VAMobile/src/api/secureMessaging/getThread.tsx
@@ -23,6 +23,7 @@ const getThread = (
 export const useThread = (messageID: number, excludeProvidedMessage: boolean, options?: { enabled?: boolean }) => {
   return useQuery({
     ...options,
+    staleTime: 0,
     queryKey: [secureMessagingKeys.thread, messageID, excludeProvidedMessage],
     queryFn: () => getThread(messageID, excludeProvidedMessage),
     meta: {

--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/CancelConfirmations/ComposeCancelConfirmation.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/CancelConfirmations/ComposeCancelConfirmation.tsx
@@ -75,6 +75,9 @@ export function useComposeCancelConfirmation(): [
               queryClient.invalidateQueries({
                 queryKey: [secureMessagingKeys.folderMessages, SecureMessagingSystemFolderIdConstants.DRAFTS, 1],
               })
+              queryClient.invalidateQueries({
+                queryKey: [secureMessagingKeys.message, draftMessageID],
+              })
               navigateTo('FolderMessages', {
                 folderID: SecureMessagingSystemFolderIdConstants.DRAFTS,
                 folderName: FolderNameTypeConstants.drafts,

--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/EditDraft/EditDraft.test.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/EditDraft/EditDraft.test.tsx
@@ -221,7 +221,9 @@ context('EditDraft', () => {
   describe('when no recipients are returned', () => {
     it('should display an AlertBox and on click of Go to inbox it should navigate', async () => {
       when(api.get as jest.Mock)
-        .calledWith(`/v1/messaging/health/messages/${3}/thread?excludeProvidedMessage=false`)
+        .calledWith(`/v1/messaging/health/messages/${3}/thread?excludeProvidedMessage=false`, {
+          useCache: 'false',
+        })
         .mockResolvedValue(thread)
         .calledWith(`/v0/messaging/health/messages/${3}`)
         .mockResolvedValue(message)
@@ -245,7 +247,9 @@ context('EditDraft', () => {
   describe('when there is an error', () => {
     it('should display the ErrorComponent', async () => {
       when(api.get as jest.Mock)
-        .calledWith(`/v1/messaging/health/messages/${3}/thread?excludeProvidedMessage=false`)
+        .calledWith(`/v1/messaging/health/messages/${3}/thread?excludeProvidedMessage=false`, {
+          useCache: 'false',
+        })
         .mockResolvedValue(thread)
         .calledWith(`/v0/messaging/health/messages/${3}`)
         .mockResolvedValue(message)
@@ -259,7 +263,9 @@ context('EditDraft', () => {
   describe('when there are no recent messages', () => {
     it('should display an alert and should hide the Add Files button and Send button', async () => {
       when(api.get as jest.Mock)
-        .calledWith(`/v1/messaging/health/messages/${3}/thread?excludeProvidedMessage=false`)
+        .calledWith(`/v1/messaging/health/messages/${3}/thread?excludeProvidedMessage=false`, {
+          useCache: 'false',
+        })
         .mockResolvedValue(oldThread)
         .calledWith(`/v0/messaging/health/messages/${3}`)
         .mockResolvedValue(message)
@@ -277,7 +283,9 @@ context('EditDraft', () => {
   describe('on click of the collapsible view', () => {
     it('should show the Reply Help panel', async () => {
       when(api.get as jest.Mock)
-        .calledWith(`/v1/messaging/health/messages/${3}/thread?excludeProvidedMessage=false`)
+        .calledWith(`/v1/messaging/health/messages/${3}/thread?excludeProvidedMessage=false`, {
+          useCache: 'false',
+        })
         .mockResolvedValue(thread)
         .calledWith(`/v0/messaging/health/messages/${3}`)
         .mockResolvedValue(message)
@@ -292,7 +300,9 @@ context('EditDraft', () => {
   describe('when pressing the back button', () => {
     it('should ask for confirmation if any field filled in', async () => {
       when(api.get as jest.Mock)
-        .calledWith(`/v1/messaging/health/messages/${3}/thread?excludeProvidedMessage=false`)
+        .calledWith(`/v1/messaging/health/messages/${3}/thread?excludeProvidedMessage=false`, {
+          useCache: 'false',
+        })
         .mockResolvedValue(thread)
         .calledWith(`/v0/messaging/health/messages/${3}`)
         .mockResolvedValue(message)
@@ -309,7 +319,9 @@ context('EditDraft', () => {
   describe('on click of add files button', () => {
     it('should call useRouteNavigation', async () => {
       when(api.get as jest.Mock)
-        .calledWith(`/v1/messaging/health/messages/${3}/thread?excludeProvidedMessage=false`)
+        .calledWith(`/v1/messaging/health/messages/${3}/thread?excludeProvidedMessage=false`, {
+          useCache: 'false',
+        })
         .mockResolvedValue(thread)
         .calledWith(`/v0/messaging/health/messages/${3}`)
         .mockResolvedValue(message)

--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/EditDraft/EditDraft.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/EditDraft/EditDraft.tsx
@@ -479,14 +479,12 @@ function EditDraft({ navigation, route }: EditDraftProps) {
           onSuccess: () => {
             showSnackBar(saveSnackbarMessages.successMsg, dispatch, undefined, true, false, true)
             logAnalyticsEvent(Events.vama_sm_save_draft(messageData.category))
-            queryClient.invalidateQueries(
-              {
-                queryKey: [secureMessagingKeys.folderMessages, SecureMessagingSystemFolderIdConstants.DRAFTS, 1],
-              },
-              {
-                queryKey: [secureMessagingKeys.message, messageID],
-              },
-            )
+            queryClient.invalidateQueries({
+              queryKey: [secureMessagingKeys.message, messageID],
+            })
+            queryClient.invalidateQueries({
+              queryKey: [secureMessagingKeys.folderMessages, SecureMessagingSystemFolderIdConstants.DRAFTS, 1],
+            })
             goToDraftFolder(true)
           },
           onError: () => {

--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/EditDraft/EditDraft.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/EditDraft/EditDraft.tsx
@@ -479,9 +479,14 @@ function EditDraft({ navigation, route }: EditDraftProps) {
           onSuccess: () => {
             showSnackBar(saveSnackbarMessages.successMsg, dispatch, undefined, true, false, true)
             logAnalyticsEvent(Events.vama_sm_save_draft(messageData.category))
-            queryClient.invalidateQueries({
-              queryKey: [secureMessagingKeys.folderMessages, SecureMessagingSystemFolderIdConstants.DRAFTS, 1],
-            })
+            queryClient.invalidateQueries(
+              {
+                queryKey: [secureMessagingKeys.folderMessages, SecureMessagingSystemFolderIdConstants.DRAFTS, 1],
+              },
+              {
+                queryKey: [secureMessagingKeys.message, messageID],
+              },
+            )
             goToDraftFolder(true)
           },
           onError: () => {

--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/ReplyMessage/ReplyMessage.test.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/ReplyMessage/ReplyMessage.test.tsx
@@ -134,7 +134,9 @@ context('ReplyMessage', () => {
     )
 
     when(api.get as jest.Mock)
-      .calledWith(`/v1/messaging/health/messages/3/thread?excludeProvidedMessage=${false}`)
+      .calledWith(`/v1/messaging/health/messages/3/thread?excludeProvidedMessage=${false}`, {
+        useCache: 'false',
+      })
       .mockResolvedValue(thread)
       .calledWith(`/v0/messaging/health/messages/3`)
       .mockResolvedValue(message)

--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/ViewMessage/CollapsibleMessage.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/ViewMessage/CollapsibleMessage.tsx
@@ -2,6 +2,8 @@ import React, { Ref, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { View } from 'react-native'
 
+import { useIsFocused } from '@react-navigation/native'
+
 import { useDownloadFileAttachment, useMessage } from 'api/secureMessaging'
 import { SecureMessagingAttachment, SecureMessagingMessageAttributes } from 'api/types'
 import {
@@ -35,6 +37,7 @@ export type ThreadMessageProps = {
 
 function CollapsibleMessage({ message, isInitialMessage, collapsibleMessageRef }: ThreadMessageProps) {
   const theme = useTheme()
+  const isFocused = useIsFocused()
   const { t } = useTranslation(NAMESPACE.COMMON)
   const { t: tFunction } = useTranslation()
   const { condensedMarginBetween } = theme.dimensions
@@ -47,7 +50,7 @@ function CollapsibleMessage({ message, isInitialMessage, collapsibleMessageRef }
     isFetched: fetchedMessage,
     refetch: fetchMessage,
   } = useMessage(message.messageId, {
-    enabled: false,
+    enabled: false && isFocused,
   })
   const { refetch: refetchFile, isFetching: attachmentFetchPending } = useDownloadFileAttachment(fileToGet, {
     enabled: false,

--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/ViewMessage/ViewMessageScreen.test.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/ViewMessage/ViewMessageScreen.test.tsx
@@ -214,7 +214,9 @@ context('ViewMessageScreen', () => {
   describe('when latest message is older than 45 days', () => {
     it('should have the Start new message button', async () => {
       when(api.get as jest.Mock)
-        .calledWith(`/v1/messaging/health/messages/${45}/thread?excludeProvidedMessage=${true}`)
+        .calledWith(`/v1/messaging/health/messages/${45}/thread?excludeProvidedMessage=${true}`, {
+          useCache: 'false',
+        })
         .mockResolvedValue(oldThread)
         .calledWith(`/v0/messaging/health/messages/${45}`)
         .mockResolvedValue(oldMessage)
@@ -230,7 +232,9 @@ context('ViewMessageScreen', () => {
   describe('Should load the screen correctly', () => {
     it('renders correct amount of CollapsibleMessages', async () => {
       when(api.get as jest.Mock)
-        .calledWith(`/v1/messaging/health/messages/${3}/thread?excludeProvidedMessage=${true}`)
+        .calledWith(`/v1/messaging/health/messages/${3}/thread?excludeProvidedMessage=${true}`, {
+          useCache: 'false',
+        })
         .mockResolvedValue(thread)
         .calledWith(`/v0/messaging/health/messages/${3}`)
         .mockResolvedValue(message)


### PR DESCRIPTION
## Description of Change
Found when saving a draft, sending draft, or saving reply or sending a reply that if you opened up a thread previously in the view message screen that the thread would not be updated immediately if the thread hasn't been made stale yet. So this forces a refetch of the thread each time to catch those scenarios

## Screenshots/Video
N/A

## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
Should have new message or change in message in thread

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
