### PR TITLE
CU/7951-Dylan-UnitTestAuthServicesMock

### DIFF
--- a/VAMobile/src/components/Nametag/Nametag.test.tsx
+++ b/VAMobile/src/components/Nametag/Nametag.test.tsx
@@ -17,34 +17,6 @@ jest.mock('utils/hooks', () => {
   }
 })
 
-jest.mock('../../api/authorizedServices/getAuthorizedServices', () => {
-  const original = jest.requireActual('../../api/authorizedServices/getAuthorizedServices')
-  return {
-    ...original,
-    useAuthorizedServices: jest.fn().mockReturnValue({
-      status: 'success',
-      data: {
-        appeals: true,
-        appointments: true,
-        claims: true,
-        decisionLetters: true,
-        directDepositBenefits: true,
-        directDepositBenefitsUpdate: true,
-        disabilityRating: true,
-        genderIdentity: true,
-        lettersAndDocuments: true,
-        militaryServiceHistory: true,
-        paymentHistory: true,
-        preferredName: true,
-        prescriptions: true,
-        scheduleAppointments: true,
-        secureMessaging: true,
-        userProfileUpdate: true,
-      },
-    }),
-  }
-})
-
 context('Nametag', () => {
   const renderWithBranch = (serviceHistory: ServiceHistoryAttributes) => {
     const queriesData: QueriesData = [

--- a/VAMobile/src/screens/BenefitsScreen/Letters/LettersOverviewScreen.test.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/Letters/LettersOverviewScreen.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { fireEvent, screen } from '@testing-library/react-native'
 
+import { authorizedServicesKeys } from 'api/authorizedServices/queryKeys'
 import { profileAddressOptions } from 'screens/HomeScreen/ProfileScreen/ContactInformationScreen/AddressSummary'
 import { context, mockNavProps, render } from 'testUtils'
 
@@ -16,22 +17,33 @@ jest.mock('utils/hooks', () => {
   }
 })
 
-const authorizedServicesMockData = { lettersAndDocuments: true }
-jest.mock('../../../api/authorizedServices/getAuthorizedServices', () => {
-  const original = jest.requireActual('../../../api/authorizedServices/getAuthorizedServices')
-  return {
-    ...original,
-    useAuthorizedServices: jest.fn().mockReturnValue({
-      status: 'success',
-      data: authorizedServicesMockData,
-    }),
-  }
-})
-
 context('LettersOverviewScreen', () => {
   const initializeTestInstance = (isAuthorized = true) => {
-    authorizedServicesMockData.lettersAndDocuments = isAuthorized
-    render(<LettersOverviewScreen {...mockNavProps()} />)
+    render(<LettersOverviewScreen {...mockNavProps()} />, {
+      queriesData: [
+        {
+          queryKey: authorizedServicesKeys.authorizedServices,
+          data: {
+            appeals: true,
+            appointments: true,
+            claims: true,
+            decisionLetters: true,
+            directDepositBenefits: true,
+            directDepositBenefitsUpdate: true,
+            disabilityRating: true,
+            genderIdentity: true,
+            lettersAndDocuments: isAuthorized,
+            militaryServiceHistory: true,
+            paymentHistory: true,
+            preferredName: true,
+            prescriptions: true,
+            scheduleAppointments: true,
+            secureMessaging: true,
+            userProfileUpdate: true,
+          },
+        },
+      ],
+    })
   }
 
   beforeEach(() => {

--- a/VAMobile/src/screens/HealthScreen/Appointments/Appointments.test.tsx
+++ b/VAMobile/src/screens/HealthScreen/Appointments/Appointments.test.tsx
@@ -8,34 +8,6 @@ import { context, mockNavProps, render, waitFor, when } from 'testUtils'
 
 import Appointments from './Appointments'
 
-jest.mock('../../../api/authorizedServices/getAuthorizedServices', () => {
-  const original = jest.requireActual('../../../api/authorizedServices/getAuthorizedServices')
-  return {
-    ...original,
-    useAuthorizedServices: jest.fn().mockReturnValue({
-      status: 'success',
-      data: {
-        appeals: true,
-        appointments: true,
-        claims: true,
-        decisionLetters: true,
-        directDepositBenefits: true,
-        directDepositBenefitsUpdate: true,
-        disabilityRating: true,
-        genderIdentity: true,
-        lettersAndDocuments: true,
-        militaryServiceHistory: true,
-        paymentHistory: true,
-        preferredName: true,
-        prescriptions: true,
-        scheduleAppointments: true,
-        secureMessaging: true,
-        userProfileUpdate: true,
-      },
-    }),
-  }
-})
-
 jest.mock('utils/remoteConfig')
 
 context('AppointmentsScreen', () => {

--- a/VAMobile/src/screens/HealthScreen/HealthScreen.test.tsx
+++ b/VAMobile/src/screens/HealthScreen/HealthScreen.test.tsx
@@ -12,34 +12,6 @@ import { HealthScreen } from './HealthScreen'
 
 const mockNavigationSpy = jest.fn()
 
-jest.mock('../../api/authorizedServices/getAuthorizedServices', () => {
-  const original = jest.requireActual('../../api/authorizedServices/getAuthorizedServices')
-  return {
-    ...original,
-    useAuthorizedServices: jest.fn().mockReturnValue({
-      status: 'success',
-      data: {
-        appeals: true,
-        appointments: true,
-        claims: true,
-        decisionLetters: true,
-        directDepositBenefits: true,
-        directDepositBenefitsUpdate: true,
-        disabilityRating: true,
-        genderIdentity: true,
-        lettersAndDocuments: true,
-        militaryServiceHistory: true,
-        paymentHistory: true,
-        preferredName: true,
-        prescriptions: true,
-        scheduleAppointments: true,
-        secureMessaging: true,
-        userProfileUpdate: true,
-      },
-    }),
-  }
-})
-
 jest.mock('utils/remoteConfig')
 
 jest.mock('utils/hooks', () => {

--- a/VAMobile/src/screens/HealthScreen/Pharmacy/PrescriptionHistory/PrescriptionHistory.test.tsx
+++ b/VAMobile/src/screens/HealthScreen/Pharmacy/PrescriptionHistory/PrescriptionHistory.test.tsx
@@ -8,34 +8,6 @@ import { context, mockNavProps, render, waitFor, when } from 'testUtils'
 
 import PrescriptionHistory from './PrescriptionHistory'
 
-jest.mock('../../../../api/authorizedServices/getAuthorizedServices', () => {
-  const original = jest.requireActual('../../../../api/authorizedServices/getAuthorizedServices')
-  return {
-    ...original,
-    useAuthorizedServices: jest.fn().mockReturnValue({
-      status: 'success',
-      data: {
-        appeals: true,
-        appointments: true,
-        claims: true,
-        decisionLetters: true,
-        directDepositBenefits: true,
-        directDepositBenefitsUpdate: true,
-        disabilityRating: true,
-        genderIdentity: true,
-        lettersAndDocuments: true,
-        militaryServiceHistory: true,
-        paymentHistory: true,
-        preferredName: true,
-        prescriptions: true,
-        scheduleAppointments: true,
-        secureMessaging: true,
-        userProfileUpdate: true,
-      },
-    }),
-  }
-})
-
 const prescriptionData: PrescriptionsGetData = {
   data: [
     {

--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/SecureMessaging.test.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/SecureMessaging.test.tsx
@@ -2,65 +2,15 @@ import React from 'react'
 
 import { screen } from '@testing-library/react-native'
 
+import { authorizedServicesKeys } from 'api/authorizedServices/queryKeys'
 import { SecureMessagingSystemFolderIdConstants } from 'api/types'
 import * as api from 'store/api'
 import { context, mockNavProps, render, waitFor, when } from 'testUtils'
 
 import SecureMessaging from './SecureMessaging'
 
-jest.mock('../../../api/authorizedServices/getAuthorizedServices', () => {
-  const original = jest.requireActual('../../../api/authorizedServices/getAuthorizedServices')
-  return {
-    ...original,
-    useAuthorizedServices: jest
-      .fn()
-      .mockReturnValue({
-        status: 'success',
-        data: {
-          appeals: true,
-          appointments: true,
-          claims: true,
-          decisionLetters: true,
-          directDepositBenefits: true,
-          directDepositBenefitsUpdate: true,
-          disabilityRating: true,
-          genderIdentity: true,
-          lettersAndDocuments: true,
-          militaryServiceHistory: true,
-          paymentHistory: true,
-          preferredName: true,
-          prescriptions: true,
-          scheduleAppointments: true,
-          secureMessaging: true,
-          userProfileUpdate: true,
-        },
-      })
-      .mockReturnValueOnce({
-        status: 'success',
-        data: {
-          appeals: true,
-          appointments: true,
-          claims: true,
-          decisionLetters: true,
-          directDepositBenefits: true,
-          directDepositBenefitsUpdate: true,
-          disabilityRating: true,
-          genderIdentity: true,
-          lettersAndDocuments: true,
-          militaryServiceHistory: true,
-          paymentHistory: true,
-          preferredName: true,
-          prescriptions: true,
-          scheduleAppointments: true,
-          secureMessaging: false,
-          userProfileUpdate: true,
-        },
-      }),
-  }
-})
-
 context('SecureMessaging', () => {
-  const initializeTestInstance = () => {
+  const initializeTestInstance = (authorized = true) => {
     render(
       <SecureMessaging
         {...mockNavProps(
@@ -73,13 +23,40 @@ context('SecureMessaging', () => {
           { params: { activeTab: 0 } },
         )}
       />,
+      {
+        queriesData: [
+          {
+            queryKey: authorizedServicesKeys.authorizedServices,
+            data: {
+              appeals: true,
+              appointments: true,
+              claims: true,
+              decisionLetters: true,
+              directDepositBenefits: true,
+              directDepositBenefitsUpdate: true,
+              disabilityRating: true,
+              genderIdentity: true,
+              lettersAndDocuments: true,
+              militaryServiceHistory: true,
+              paymentHistory: true,
+              preferredName: true,
+              prescriptions: true,
+              scheduleAppointments: true,
+              secureMessaging: authorized,
+              userProfileUpdate: true,
+            },
+          },
+        ],
+      },
     )
   }
 
   describe('when user is not authorized for secure messaging', () => {
-    it('should display NotEnrolledSM component', () => {
-      initializeTestInstance()
-      expect(screen.getByText("You're not currently enrolled to use Secure Messaging")).toBeTruthy()
+    it('should display NotEnrolledSM component', async () => {
+      initializeTestInstance(false)
+      await waitFor(() =>
+        expect(screen.getByText("You're not currently enrolled to use Secure Messaging")).toBeTruthy(),
+      )
     })
   })
 

--- a/VAMobile/src/screens/HomeScreen/ProfileScreen/MilitaryInformationScreen/MilitaryInformationScreen.test.tsx
+++ b/VAMobile/src/screens/HomeScreen/ProfileScreen/MilitaryInformationScreen/MilitaryInformationScreen.test.tsx
@@ -10,57 +10,6 @@ import { QueriesData, context, mockNavProps, render, when } from 'testUtils'
 
 import MilitaryInformationScreen from './index'
 
-jest.mock('../../../../api/authorizedServices/getAuthorizedServices', () => {
-  const original = jest.requireActual('../../../../api/authorizedServices/getAuthorizedServices')
-  return {
-    ...original,
-    useAuthorizedServices: jest
-      .fn()
-      .mockReturnValue({
-        status: 'success',
-        data: {
-          appeals: true,
-          appointments: true,
-          claims: true,
-          decisionLetters: true,
-          directDepositBenefits: true,
-          directDepositBenefitsUpdate: true,
-          disabilityRating: true,
-          genderIdentity: true,
-          lettersAndDocuments: true,
-          militaryServiceHistory: true,
-          paymentHistory: true,
-          preferredName: true,
-          prescriptions: true,
-          scheduleAppointments: true,
-          secureMessaging: true,
-          userProfileUpdate: true,
-        },
-      })
-      .mockReturnValueOnce({
-        status: 'success',
-        data: {
-          appeals: true,
-          appointments: true,
-          claims: true,
-          decisionLetters: true,
-          directDepositBenefits: true,
-          directDepositBenefitsUpdate: true,
-          disabilityRating: true,
-          genderIdentity: true,
-          lettersAndDocuments: true,
-          militaryServiceHistory: false,
-          paymentHistory: true,
-          preferredName: true,
-          prescriptions: true,
-          scheduleAppointments: true,
-          secureMessaging: true,
-          userProfileUpdate: true,
-        },
-      }),
-  }
-})
-
 context('MilitaryInformationScreen', () => {
   const serviceHistoryMock: ServiceHistoryAttributes = {
     serviceHistory: [

--- a/VAMobile/src/screens/HomeScreen/ProfileScreen/ProfileScreen.test.tsx
+++ b/VAMobile/src/screens/HomeScreen/ProfileScreen/ProfileScreen.test.tsx
@@ -8,34 +8,6 @@ import { context, mockNavProps, render, waitFor, when } from 'testUtils'
 
 import ProfileScreen from './ProfileScreen'
 
-jest.mock('../../../api/authorizedServices/getAuthorizedServices', () => {
-  const original = jest.requireActual('../../../api/authorizedServices/getAuthorizedServices')
-  return {
-    ...original,
-    useAuthorizedServices: jest.fn().mockReturnValue({
-      status: 'success',
-      data: {
-        appeals: true,
-        appointments: true,
-        claims: true,
-        decisionLetters: true,
-        directDepositBenefits: true,
-        directDepositBenefitsUpdate: true,
-        disabilityRating: true,
-        genderIdentity: true,
-        lettersAndDocuments: true,
-        militaryServiceHistory: true,
-        paymentHistory: true,
-        preferredName: true,
-        prescriptions: true,
-        scheduleAppointments: true,
-        secureMessaging: true,
-        userProfileUpdate: false,
-      },
-    }),
-  }
-})
-
 const mockNavigationSpy = jest.fn()
 jest.mock('utils/hooks', () => {
   const original = jest.requireActual('utils/hooks')

--- a/VAMobile/src/screens/PaymentsScreen/PaymentsScreen.test.tsx
+++ b/VAMobile/src/screens/PaymentsScreen/PaymentsScreen.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { fireEvent, screen } from '@testing-library/react-native'
 
+import { authorizedServicesKeys } from 'api/authorizedServices/queryKeys'
 import { context, render } from 'testUtils'
 
 import PaymentsScreen from './index'
@@ -15,65 +16,38 @@ jest.mock('utils/hooks', () => {
   }
 })
 
-jest.mock('../../api/authorizedServices/getAuthorizedServices', () => {
-  const original = jest.requireActual('../../api/authorizedServices/getAuthorizedServices')
-  return {
-    ...original,
-    useAuthorizedServices: jest
-      .fn()
-      .mockReturnValueOnce({
-        status: 'success',
-        data: {
-          appeals: true,
-          appointments: true,
-          claims: true,
-          decisionLetters: true,
-          directDepositBenefits: true,
-          directDepositBenefitsUpdate: false,
-          disabilityRating: true,
-          genderIdentity: true,
-          lettersAndDocuments: true,
-          militaryServiceHistory: true,
-          paymentHistory: true,
-          preferredName: true,
-          prescriptions: true,
-          scheduleAppointments: true,
-          secureMessaging: true,
-          userProfileUpdate: true,
-        },
-      })
-      .mockReturnValue({
-        status: 'success',
-        data: {
-          appeals: true,
-          appointments: true,
-          claims: true,
-          decisionLetters: true,
-          directDepositBenefits: true,
-          directDepositBenefitsUpdate: true,
-          disabilityRating: true,
-          genderIdentity: true,
-          lettersAndDocuments: true,
-          militaryServiceHistory: true,
-          paymentHistory: true,
-          preferredName: true,
-          prescriptions: true,
-          scheduleAppointments: true,
-          secureMessaging: true,
-          userProfileUpdate: true,
-        },
-      }),
-  }
-})
-
 context('PaymentsScreen', () => {
-  const initializeTestInstance = (): void => {
-    render(<PaymentsScreen />)
+  const initializeTestInstance = (authorized = true): void => {
+    render(<PaymentsScreen />, {
+      queriesData: [
+        {
+          queryKey: authorizedServicesKeys.authorizedServices,
+          data: {
+            appeals: true,
+            appointments: true,
+            claims: true,
+            decisionLetters: true,
+            directDepositBenefits: true,
+            directDepositBenefitsUpdate: authorized,
+            disabilityRating: true,
+            genderIdentity: true,
+            lettersAndDocuments: true,
+            militaryServiceHistory: true,
+            paymentHistory: true,
+            preferredName: true,
+            prescriptions: true,
+            scheduleAppointments: true,
+            secureMessaging: true,
+            userProfileUpdate: true,
+          },
+        },
+      ],
+    })
   }
 
   describe('when user does not have directDepositBenefits', () => {
     it('should navigate to HowToUpdateDirectDeposit', () => {
-      initializeTestInstance()
+      initializeTestInstance(false)
       fireEvent.press(screen.getByRole('menuitem', { name: 'Direct deposit information' }))
       expect(mockNavigationSpy).toHaveBeenCalledWith('HowToUpdateDirectDeposit')
     })

--- a/VAMobile/src/screens/SyncScreen/SyncScreen.test.tsx
+++ b/VAMobile/src/screens/SyncScreen/SyncScreen.test.tsx
@@ -20,34 +20,6 @@ jest.mock('store/slices', () => {
   }
 })
 
-jest.mock('../../api/authorizedServices/getAuthorizedServices', () => {
-  const original = jest.requireActual('../../api/authorizedServices/getAuthorizedServices')
-  return {
-    ...original,
-    useAuthorizedServices: jest.fn().mockReturnValue({
-      status: 'success',
-      data: {
-        appeals: true,
-        appointments: true,
-        claims: true,
-        decisionLetters: true,
-        directDepositBenefits: true,
-        directDepositBenefitsUpdate: true,
-        disabilityRating: true,
-        genderIdentity: true,
-        lettersAndDocuments: true,
-        militaryServiceHistory: true,
-        paymentHistory: true,
-        preferredName: true,
-        prescriptions: true,
-        scheduleAppointments: true,
-        secureMessaging: true,
-        userProfileUpdate: true,
-      },
-    }),
-  }
-})
-
 context('SyncScreen', () => {
   const initializeTestInstance = (loggedIn = false, loggingOut = false, syncing = true): void => {
     const store = {


### PR DESCRIPTION
## Description of Change
updated mock to not use jest, but instead use queries data and removed no longer needed mocks

## Screenshots/Video
N/A

## Testing
Yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
mock should no longer use the jest way and instead use queries data

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
