### PR TITLE
bug/8598-Dylan-AndroidTextLeftAlignmentNativeActionSheets

### DIFF
--- a/VAMobile/src/utils/hooks/index.tsx
+++ b/VAMobile/src/utils/hooks/index.tsx
@@ -306,9 +306,17 @@ export function useDestructiveActionSheet(): (props: useDestructiveActionSheetPr
     showActionSheetWithOptions(
       {
         title: props.title,
-        titleTextStyle: { fontWeight: 'bold', textAlign: 'center', color: currentTheme.colors.text.primary },
+        titleTextStyle: {
+          fontWeight: 'bold',
+          textAlign: isIOS() ? 'center' : 'left',
+          color: currentTheme.colors.text.primary,
+        },
         message: props.message,
-        messageTextStyle: { fontWeight: 'normal', textAlign: 'center', color: currentTheme.colors.text.primary },
+        messageTextStyle: {
+          fontWeight: 'normal',
+          textAlign: isIOS() ? 'center' : 'left',
+          color: currentTheme.colors.text.primary,
+        },
         textStyle: { color: currentTheme.colors.text.primary },
         destructiveButtonIndex: newDestructiveButtonIndex,
         destructiveColor: currentTheme.colors.text.error,
@@ -514,8 +522,12 @@ export function useShowActionSheet(): (
     })
 
     const casedOptions: ActionSheetOptions = {
-      titleTextStyle: { fontWeight: 'bold', textAlign: 'center', color: currentTheme.colors.text.primary },
-      messageTextStyle: { textAlign: 'center', color: currentTheme.colors.text.primary },
+      titleTextStyle: {
+        fontWeight: 'bold',
+        textAlign: isIOS() ? 'center' : 'left',
+        color: currentTheme.colors.text.primary,
+      },
+      messageTextStyle: { textAlign: isIOS() ? 'center' : 'left', color: currentTheme.colors.text.primary },
       textStyle: { color: currentTheme.colors.text.primary },
       destructiveColor: currentTheme.colors.text.error,
       containerStyle: { backgroundColor: currentTheme.colors.background.contentBox },

--- a/VAMobile/src/utils/hooks/index.tsx
+++ b/VAMobile/src/utils/hooks/index.tsx
@@ -46,7 +46,7 @@ import { capitalizeFirstLetter, stringToTitleCase } from 'utils/formattingUtils'
 import { isAndroid, isIOS, isIpad } from 'utils/platform'
 import { WaygateToggleType, waygateNativeAlert } from 'utils/waygateConfig'
 
-const textAlightment = isIOS() ? 'center' : 'left'
+const textAlign = isIOS() ? 'center' : 'left'
 /**
  * Hook to determine if an error should be shown for a given screen id
  * @param currentScreenID - the id of the screen being check for errors
@@ -309,13 +309,13 @@ export function useDestructiveActionSheet(): (props: useDestructiveActionSheetPr
         title: props.title,
         titleTextStyle: {
           fontWeight: 'bold',
-          textAlign: textAlightment,
+          textAlign: textAlign,
           color: currentTheme.colors.text.primary,
         },
         message: props.message,
         messageTextStyle: {
           fontWeight: 'normal',
-          textAlign: textAlightment,
+          textAlign: textAlign,
           color: currentTheme.colors.text.primary,
         },
         textStyle: { color: currentTheme.colors.text.primary },
@@ -525,10 +525,10 @@ export function useShowActionSheet(): (
     const casedOptions: ActionSheetOptions = {
       titleTextStyle: {
         fontWeight: 'bold',
-        textAlign: textAlightment,
+        textAlign: textAlign,
         color: currentTheme.colors.text.primary,
       },
-      messageTextStyle: { textAlign: textAlightment, color: currentTheme.colors.text.primary },
+      messageTextStyle: { textAlign: textAlign, color: currentTheme.colors.text.primary },
       textStyle: { color: currentTheme.colors.text.primary },
       destructiveColor: currentTheme.colors.text.error,
       containerStyle: { backgroundColor: currentTheme.colors.background.contentBox },

--- a/VAMobile/src/utils/hooks/index.tsx
+++ b/VAMobile/src/utils/hooks/index.tsx
@@ -46,6 +46,7 @@ import { capitalizeFirstLetter, stringToTitleCase } from 'utils/formattingUtils'
 import { isAndroid, isIOS, isIpad } from 'utils/platform'
 import { WaygateToggleType, waygateNativeAlert } from 'utils/waygateConfig'
 
+const textAlightment = isIOS() ? 'center' : 'left'
 /**
  * Hook to determine if an error should be shown for a given screen id
  * @param currentScreenID - the id of the screen being check for errors
@@ -308,13 +309,13 @@ export function useDestructiveActionSheet(): (props: useDestructiveActionSheetPr
         title: props.title,
         titleTextStyle: {
           fontWeight: 'bold',
-          textAlign: isIOS() ? 'center' : 'left',
+          textAlign: textAlightment,
           color: currentTheme.colors.text.primary,
         },
         message: props.message,
         messageTextStyle: {
           fontWeight: 'normal',
-          textAlign: isIOS() ? 'center' : 'left',
+          textAlign: textAlightment,
           color: currentTheme.colors.text.primary,
         },
         textStyle: { color: currentTheme.colors.text.primary },
@@ -524,10 +525,10 @@ export function useShowActionSheet(): (
     const casedOptions: ActionSheetOptions = {
       titleTextStyle: {
         fontWeight: 'bold',
-        textAlign: isIOS() ? 'center' : 'left',
+        textAlign: textAlightment,
         color: currentTheme.colors.text.primary,
       },
-      messageTextStyle: { textAlign: isIOS() ? 'center' : 'left', color: currentTheme.colors.text.primary },
+      messageTextStyle: { textAlign: textAlightment, color: currentTheme.colors.text.primary },
       textStyle: { color: currentTheme.colors.text.primary },
       destructiveColor: currentTheme.colors.text.error,
       containerStyle: { backgroundColor: currentTheme.colors.background.contentBox },


### PR DESCRIPTION
## Description of Change
Change the alignment for Android action sheets only to left. iOS remains unchanged

## Screenshots/Video
<img width="502" alt="Screenshot 2024-06-14 at 12 29 01 PM" src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/04daef45-b807-4073-92b1-b2ca1befc3ca">


## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
if this change will result in changing [native iOS action sheets](https://developer.apple.com/design/human-interface-guidelines/action-sheets#Best-practices), then no, let's not do it. We don't want to override the iOS appearance at all.

If you can achieve the fix only for Android, then sure – align left.

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
