### PR TITLE
Enable sourcemaps for iOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ coverage
 **/ios/output
 **/ios/vendor
 **/ios/Pods
+**/ios/main.jsbundle.map
 
 # Xcode
 #

--- a/VAMobile/package.json
+++ b/VAMobile/package.json
@@ -14,7 +14,7 @@
     "clean:android": "cd android; ./gradlew clean",
     "clean:ios": "rm -rf ./ios/output",
     "bundle:android": "react-native bundle --reset-cache --platform android --dev false --entry-file index.js --bundle-output android/app/src/main/assets/index.android.bundle",
-    "bundle:ios": "react-native bundle --reset-cache --dev false --entry-file index.js --bundle-output ios/main.jsbundle --platform ios",
+    "bundle:ios": "react-native bundle --reset-cache --dev false --entry-file index.js --bundle-output ios/main.jsbundle --platform ios --sourcemap-output ios/main.jsbundle.map",
     "lint:watch": "watch --wait=2 'yarn run lint:forWatcher' ./src",
     "lint": "eslint ./src --ext .js,.jsx,.ts,.tsx",
     "tsc:compile": "tsc -p ./tsconfig.app.json",


### PR DESCRIPTION
## Description of Change

Our logs in firebase aren't very helpful, so we want to switch on sourcemaps. This is the PR for iOS. Having a little trouble with Android



## Testing

Build output says "info Writing sourcemap output to:, ios/main.jsbundle.map" - run `yarn bundle:ios` and you should see it

## Reviewer Validations
<!-- What should reviewers look for? Copy/paste Acceptance Criteria from ticket -->

## PR Checklist

- [x] PR is connected to issue(s)
- [ ] Tests are included to cover this change (when possible)
- [ ] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [ ] No secrets or API keys are checked in
- [ ] All imports are absolute (no relative imports)
- [ ] New functions and Redux work have proper TSDoc annotations
