### PR TITLE
Updated detox scripts to clear jest cache

### DIFF
--- a/VAMobile/package.json
+++ b/VAMobile/package.json
@@ -29,9 +29,9 @@
     "postinstall": "yarn prepare",
     "prepare": "cd .. && husky VAMobile/.husky",
     "e2e:ios-build": "yarn run bundle:ios && detox build -c ios",
-    "e2e:ios-test": "detox test -c ios --cleanup --record-logs all",
+    "e2e:ios-test": "yarn jest:clear && detox test -c ios --cleanup --record-logs all",
     "e2e:android-build": " yarn run bundle:android && detox build -c android",
-    "e2e:android-test": "detox test -c android --cleanup",
+    "e2e:android-test": "yarn jest:clear && ddetox test -c android --cleanup",
     "docs": "yarn && cd documentation && yarn && yarn start",
     "nodes": "rm -rf node_modules && yarn install",
     "pods": "cd ios && pod install && cd .."

--- a/VAMobile/package.json
+++ b/VAMobile/package.json
@@ -31,7 +31,7 @@
     "e2e:ios-build": "yarn run bundle:ios && detox build -c ios",
     "e2e:ios-test": "yarn jest:clear && detox test -c ios --cleanup --record-logs all",
     "e2e:android-build": " yarn run bundle:android && detox build -c android",
-    "e2e:android-test": "yarn jest:clear && ddetox test -c android --cleanup",
+    "e2e:android-test": "yarn jest:clear && detox test -c android --cleanup",
     "docs": "yarn && cd documentation && yarn && yarn start",
     "nodes": "rm -rf node_modules && yarn install",
     "pods": "cd ios && pod install && cd .."


### PR DESCRIPTION
## Description of Change

Detox runs are throwing a GlobalSetup error for some folks, clearing the Jest cache before each run seems to fix it.
