### PR TITLE
feature/7802-Dylan-UpdateHelpPanelLinkFromButtonToLinkComponent2

### DIFF
--- a/VAMobile/ios/Podfile.lock
+++ b/VAMobile/ios/Podfile.lock
@@ -1052,7 +1052,7 @@ PODS:
     - React-Core
   - react-native-notifications (5.1.0):
     - React-Core
-  - react-native-safe-area-context (4.10.1):
+  - react-native-safe-area-context (4.10.4):
     - React-Core
   - react-native-webview (13.8.6):
     - glog
@@ -1261,7 +1261,7 @@ PODS:
     - RNFBApp
   - RNFileViewer (2.1.5):
     - React-Core
-  - RNGestureHandler (2.14.0):
+  - RNGestureHandler (2.16.2):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
@@ -1271,10 +1271,11 @@ PODS:
     - React-Core
   - RNReactNativeHapticFeedback (2.2.0):
     - React-Core
-  - RNScreens (3.29.0):
+  - RNScreens (3.32.0):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
+    - React-RCTImage
   - RNSVG (14.1.0):
     - React-Core
   - SDWebImage/Core (5.19.1)
@@ -1599,7 +1600,7 @@ SPEC CHECKSUMS:
   react-native-document-picker: cd4d6b36a5207ad7a9e599ebb9eb0c2e84fa0b87
   react-native-image-picker: b3ba58c691bc503b33480cef8ab987f78e310c15
   react-native-notifications: 4601a5a8db4ced6ae7cfc43b44d35fe437ac50c4
-  react-native-safe-area-context: dcab599c527c2d7de2d76507a523d20a0b83823d
+  react-native-safe-area-context: 399a5859f6acbdf67f671c69b53113f535f3b5b0
   react-native-webview: d6607cbbe7bad689cc08d6d5e35cbf9938093223
   React-nativeconfig: 2e44d0d2dd222b12a5183f4bcaa4a91881497acb
   React-NativeModulesApple: 8aa032fe6c92c1a3c63e4809d42816284a56a9b0
@@ -1631,11 +1632,11 @@ SPEC CHECKSUMS:
   RNFBPerf: 9cd7430cb90e4b8aebcd86312f1eb3aae28bd0e7
   RNFBRemoteConfig: bfb9f6a04a0269038a352d8386e5c77f4ff98125
   RNFileViewer: ce7ca3ac370e18554d35d6355cffd7c30437c592
-  RNGestureHandler: a4c4561307e67f2942f5a4fe1526ff78cf3f5280
+  RNGestureHandler: 96439cf6543defdde87459e48cd1a3f0e45a008e
   RNKeychain: a65256b6ca6ba6976132cc4124b238a5b13b3d9c
   RNLocalize: e8694475db034bf601e17bd3dfa8986565e769eb
   RNReactNativeHapticFeedback: ec56a5f81c3941206fd85625fa669ffc7b4545f9
-  RNScreens: 17e2f657f1b09a71ec3c821368a04acbb7ebcb46
+  RNScreens: e842cdccb23c0a084bd6307f6fa83fd1c1738029
   RNSVG: ba3e7232f45e34b7b47e74472386cf4e1a676d0a
   SDWebImage: 40b0b4053e36c660a764958bff99eed16610acbb
   SDWebImageWebPCoder: c94f09adbca681822edad9e532ac752db713eabf

--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/EditDraft/EditDraft.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/EditDraft/EditDraft.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Pressable, ScrollView } from 'react-native'
+import { ScrollView } from 'react-native'
 
 import { StackScreenProps } from '@react-navigation/stack'
 
@@ -32,7 +32,6 @@ import {
 import {
   AlertBox,
   Box,
-  CollapsibleView,
   ErrorComponent,
   FieldType,
   FormFieldType,
@@ -592,15 +591,11 @@ function EditDraft({ navigation, route }: EditDraftProps) {
             />
           </Box>
           <Box mt={theme.dimensions.standardMarginBetween}>
-            <Pressable
+            <LinkWithAnalytics
+              type="custom"
+              text={t('secureMessaging.replyHelp.onlyUseMessages')}
               onPress={navigateToReplyHelp}
-              accessibilityRole={'button'}
-              accessibilityLabel={t('secureMessaging.replyHelp.onlyUseMessages')}
-              importantForAccessibility={'yes'}>
-              <Box pointerEvents={'none'} accessible={false} importantForAccessibility={'no-hide-descendants'}>
-                <CollapsibleView text={t('secureMessaging.replyHelp.onlyUseMessages')} showInTextArea={false} />
-              </Box>
-            </Pressable>
+            />
           </Box>
           {!replyDisabled && renderButton()}
         </TextArea>

--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/ReplyMessage/ReplyMessage.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/ReplyMessage/ReplyMessage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Pressable, ScrollView } from 'react-native'
+import { ScrollView } from 'react-native'
 
 import { StackScreenProps } from '@react-navigation/stack'
 
@@ -27,11 +27,11 @@ import {
 } from 'api/types'
 import {
   Box,
-  CollapsibleView,
   FieldType,
   FormFieldType,
   FormWrapper,
   FullScreenSubtask,
+  LinkWithAnalytics,
   LoadingComponent,
   MessageAlert,
   TextArea,
@@ -328,15 +328,11 @@ function ReplyMessage({ navigation, route }: ReplyMessageProps) {
             />
           </Box>
           <Box mt={theme.dimensions.standardMarginBetween}>
-            <Pressable
+            <LinkWithAnalytics
+              type="custom"
+              text={t('secureMessaging.replyHelp.onlyUseMessages')}
               onPress={navigateToReplyHelp}
-              accessibilityRole={'button'}
-              accessibilityLabel={t('secureMessaging.replyHelp.onlyUseMessages')}
-              importantForAccessibility={'yes'}>
-              <Box pointerEvents={'none'} accessible={false} importantForAccessibility={'no-hide-descendants'}>
-                <CollapsibleView text={t('secureMessaging.replyHelp.onlyUseMessages')} showInTextArea={false} />
-              </Box>
-            </Pressable>
+            />
           </Box>
           <Box mt={theme.dimensions.standardMarginBetween}>
             <Button

--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/StartNewMessage/StartNewMessage.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/StartNewMessage/StartNewMessage.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Pressable, ScrollView } from 'react-native'
+import { ScrollView } from 'react-native'
 
 import { StackScreenProps } from '@react-navigation/stack'
 
@@ -26,7 +26,6 @@ import {
 import {
   AlertBox,
   Box,
-  CollapsibleView,
   ErrorComponent,
   FieldType,
   FormFieldType,
@@ -413,16 +412,12 @@ function StartNewMessage({ navigation, route }: StartNewMessageProps) {
             setErrorList={setErrorList}
           />
           <Box mt={theme.dimensions.standardMarginBetween}>
-            <Pressable
+            <LinkWithAnalytics
+              type="custom"
+              text={t('secureMessaging.replyHelp.onlyUseMessages')}
               onPress={navigateToReplyHelp}
-              accessibilityRole={'button'}
-              accessibilityLabel={t('secureMessaging.replyHelp.onlyUseMessages')}
-              importantForAccessibility={'yes'}
-              testID="startNewMessageOnlyUseMessagesTestID">
-              <Box pointerEvents={'none'} accessible={false} importantForAccessibility={'no-hide-descendants'}>
-                <CollapsibleView text={t('secureMessaging.replyHelp.onlyUseMessages')} showInTextArea={false} />
-              </Box>
-            </Pressable>
+              testID="startNewMessageOnlyUseMessagesTestID"
+            />
           </Box>
           <Box mt={theme.dimensions.standardMarginBetween}>
             <Button

--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/ViewMessage/MessageCard.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/ViewMessage/MessageCard.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { useTranslation } from 'react-i18next'
-import { Pressable } from 'react-native'
 import { useSelector } from 'react-redux'
 
 import { Button } from '@department-of-veterans-affairs/mobile-component-library'
@@ -8,7 +7,7 @@ import { DateTime } from 'luxon'
 
 import { useDownloadFileAttachment } from 'api/secureMessaging'
 import { SecureMessagingAttachment, SecureMessagingMessageAttributes } from 'api/types'
-import { AttachmentLink, Box, CollapsibleView, LoadingComponent, TextView } from 'components'
+import { AttachmentLink, Box, LinkWithAnalytics, LoadingComponent, TextView } from 'components'
 import { Events } from 'constants/analytics'
 import { NAMESPACE } from 'constants/namespaces'
 import { REPLY_WINDOW_IN_DAYS } from 'constants/secureMessaging'
@@ -121,15 +120,11 @@ function MessageCard({ message }: MessageCardProps) {
   function getMessageHelp() {
     return (
       <Box mb={theme.dimensions.condensedMarginBetween}>
-        <Pressable
+        <LinkWithAnalytics
+          type="custom"
+          text={t('secureMessaging.replyHelp.onlyUseMessages')}
           onPress={navigateToReplyHelp}
-          accessibilityRole={'button'}
-          accessibilityLabel={t('secureMessaging.replyHelp.onlyUseMessages')}
-          importantForAccessibility={'yes'}>
-          <Box pointerEvents={'none'} accessible={false} importantForAccessibility={'no-hide-descendants'}>
-            <CollapsibleView text={t('secureMessaging.replyHelp.onlyUseMessages')} showInTextArea={false} />
-          </Box>
-        </Pressable>
+        />
       </Box>
     )
   }


### PR DESCRIPTION
## Description of Change
Updated the help panel text to the link component also included podfile  updates from dependabot that didn't get included

## Screenshots/Video
Toggle: <details><summary>Before/after: </summary><img src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/76bfe74d-a1b7-4f99-adbe-9e922173625b" width="49%" />&nbsp;&nbsp;<img src="https://github.com/department-of-veterans-affairs/va-mobile-app/assets/87150991/e29ad4ce-5093-4f88-85aa-4b6e2d3c8448" width="49%" /></details>

## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
Solution: Replace with current Link component, omit Additional Info Row component.

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
