### PR TITLE
bug/8904-rachael-detox-fix-multiple-slack-messages

### DIFF
--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -235,17 +235,10 @@ jobs:
       #     script: yarn e2e:android-test /e2e/tests/Navigation.e2e AvailabilityFramework.e2e ${{matrix.testsuite}}.e2e --take-screenshots failing --updateSnapshot --headless
         
       - name: Upload e2e-junit
-        if: success()
+        if: failure() || success()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{matrix.testsuite}}-pass-e2e-junit
-          path: VAMobile/e2e/test_reports/e2e-junit.xml
-      
-      - name: Upload failure e2e-junit
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{matrix.testsuite}}-failure-e2e-junit
+          name: ${{matrix.testsuite}}-e2e-junit
           path: VAMobile/e2e/test_reports/e2e-junit.xml
 
       - name: Upload artifacts on failure
@@ -271,11 +264,11 @@ jobs:
       - name: Download results
         uses: actions/download-artifact@v4
         with:
-          pattern: *-failure-e2e-junit
+            path: VAMobile/e2e/test_reports
       - name: Inform Slack
         shell: bash
         run: |
-          list=$(find . -name "*failure*")
+          list=$(find . -name "*e2e-junit")
           echo "$list" 
 #if [[ "$list" == "" ]] then;
 #  ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \

--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -268,7 +268,7 @@ jobs:
       - name: Inform Slack
         shell: bash
         run: |
-          list=$(find ./VAMobile/artifacts -name "*detox-artifacts*")
+          list=$(find . -name "*detox-artifacts*")
           echo "$list" 
 #if [[ "$list" == "" ]] then;
 #  ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \

--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -268,7 +268,7 @@ jobs:
       - name: Inform Slack
         shell: bash
         run: |
-          list=$(find /VAMobile/artifacts -name "*detox-artifacts*")
+          list=$(find ./VAMobile/artifacts -name "*detox-artifacts*")
           echo "$list" 
 #if [[ "$list" == "" ]] then;
 #  ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \

--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -268,11 +268,10 @@ jobs:
       - name: Inform Slack
         shell: bash
         run: |
-          list="$(grep -r "<failure>" .)"
-          if [[ "$list" ]] then;
+          if [[ $(grep -q -r "<failure>" .) ]]; then
             echo "found"
           else
-            echo "notFound"
+            echo "not found"
           fi
 # list=$(find . -name "*e2e-junit")
 # echo "$list" 

--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -268,8 +268,10 @@ jobs:
       - name: Inform Slack
         shell: bash
         run: |
-          list=$(find . -name "*e2e-junit")
-          echo "$list" 
+          list=$(grep -r "<failure>" ./test_reports)
+          echo "$list"
+# list=$(find . -name "*e2e-junit")
+# echo "$list" 
 #if [[ "$list" == "" ]] then;
 #  ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \
 #  -H 'Content-type: application/json' \

--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -133,7 +133,7 @@ jobs:
 
   matrix-e2e-android:
     if: (!cancelled()) && needs.output_detox_tests_to_run.outputs.output1 != ''
-    runs-on: macos-latest-xl
+    runs-on: ubuntu-latest
     needs: [start_slack_thread, output_detox_tests_to_run]
     strategy:
       fail-fast: false
@@ -243,8 +243,7 @@ jobs:
 
       - name: Create artifact
         if: failure() && steps.run_e2e_tests_nav_AF.outcome == 'failure'
-        run: |
-          echo > VAMobile/artifacts/failure.txt
+        run: echo "" > failure.txt
       
       - name: Output test failure
         id: post_failure
@@ -252,7 +251,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           overwrite: true
-          path: VAMobile/artifacts/failure.txt
+          path: failure.txt
           retention-days: 1
 
       - name: Upload artifacts on failure
@@ -277,10 +276,10 @@ jobs:
       - name: Download results
         uses: actions/download-artifact@v4
         with:
-            path: VAMobile/artifacts
+            path: artifacts
       - name: Inform Slack
         run: |
-          list=find ./VAMobile/artifacts -name "failure.txt"
+          list=find ./artifacts -name "failure.txt"
           echo "$list" 
 #if [[ "$list" == "" ]] then;
 #  ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \

--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -241,25 +241,13 @@ jobs:
           name: ${{matrix.testsuite}}-e2e-junit
           path: VAMobile/e2e/test_reports/e2e-junit.xml
 
-      - name: Create artifact
-        if: failure() && steps.run_e2e_tests_nav_AF.outcome == 'failure'
-        run: echo "" > failure.txt
-      
-      - name: Output test failure
-        id: post_failure
-        if: failure() && steps.run_e2e_tests_nav_AF.outcome == 'failure'
-        uses: actions/upload-artifact@v4
-        with:
-          overwrite: true
-          path: failure.txt
-          retention-days: 1
-
       - name: Upload artifacts on failure
-        if: failure() && steps.run_e2e_tests.outcome == 'failure'
+        if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: detox-artifacts-${{ runner.os }}-${{ github.run_id }}
           path: VAMobile/artifacts
+          retention-days: 3
 
       - name: Fail workflow if needed(View e2e step for details)
         if: steps.run_e2e_tests.outcome == 'failure'
@@ -276,10 +264,10 @@ jobs:
       - name: Download results
         uses: actions/download-artifact@v4
         with:
-            path: artifacts
+            path: VAMobile/artifacts
       - name: Inform Slack
         run: |
-          list=find ./artifacts -name "failure.txt"
+          list=find ./VAMobile/artifacts -name "*detox-artifacts*"
           echo "$list" 
 #if [[ "$list" == "" ]] then;
 #  ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \

--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -221,18 +221,18 @@ jobs:
           avd-name: Pixel_4_XL_API_28
           script: yarn e2e:android-test /e2e/tests/Navigation.e2e AvailabilityFramework.e2e ${{matrix.testsuite}}.e2e --take-screenshots failing --updateSnapshot --headless
 
-      - name: Run e2e tests for Android
-        if: failure() && steps.run_e2e_tests_nav_AF.outcome == 'failure'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          working-directory: VAMobile
-          api-level: 28
-          profile: pixel_6_pro
-          force-avd-creation: false
-          disable-animations: true
-          arch: x86_64
-          avd-name: Pixel_4_XL_API_28
-          script: yarn e2e:android-test /e2e/tests/Navigation.e2e AvailabilityFramework.e2e ${{matrix.testsuite}}.e2e --take-screenshots failing --updateSnapshot --headless
+      # - name: Run e2e tests for Android
+      #   if: failure() && steps.run_e2e_tests_nav_AF.outcome == 'failure'
+      #   uses: reactivecircus/android-emulator-runner@v2
+      #   with:
+      #     working-directory: VAMobile
+      #     api-level: 28
+      #     profile: pixel_6_pro
+      #     force-avd-creation: false
+      #     disable-animations: true
+      #     arch: x86_64
+      #     avd-name: Pixel_4_XL_API_28
+      #     script: yarn e2e:android-test /e2e/tests/Navigation.e2e AvailabilityFramework.e2e ${{matrix.testsuite}}.e2e --take-screenshots failing --updateSnapshot --headless
         
       - name: Upload e2e-junit
         if: failure() || success()

--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -268,10 +268,10 @@ jobs:
       - name: Inform Slack
         shell: bash
         run: |
-          if [[ $(grep -q -r "<failure>" .) ]]; then
-            echo "found"
-          else
+          if [[ $(grep -L -r "<failure>" .) ]]; then
             echo "not found"
+          else
+            echo "found"
           fi
 # list=$(find . -name "*e2e-junit")
 # echo "$list" 

--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -139,8 +139,6 @@ jobs:
       fail-fast: false
       matrix:
         testsuite: ${{fromJson(needs.output_detox_tests_to_run.outputs.output1)}}
-    outputs: 
-      output1: ${{ steps.post_failure.outputs.test_failure }}
 
     steps:
       - uses: actions/checkout@v3
@@ -221,18 +219,18 @@ jobs:
           avd-name: Pixel_4_XL_API_28
           script: yarn e2e:android-test /e2e/tests/Navigation.e2e AvailabilityFramework.e2e ${{matrix.testsuite}}.e2e --take-screenshots failing --updateSnapshot --headless
 
-      # - name: Run e2e tests for Android
-      #   if: failure() && steps.run_e2e_tests_nav_AF.outcome == 'failure'
-      #   uses: reactivecircus/android-emulator-runner@v2
-      #   with:
-      #     working-directory: VAMobile
-      #     api-level: 28
-      #     profile: pixel_6_pro
-      #     force-avd-creation: false
-      #     disable-animations: true
-      #     arch: x86_64
-      #     avd-name: Pixel_4_XL_API_28
-      #     script: yarn e2e:android-test /e2e/tests/Navigation.e2e AvailabilityFramework.e2e ${{matrix.testsuite}}.e2e --take-screenshots failing --updateSnapshot --headless
+      - name: Run e2e tests for Android
+        if: failure() && steps.run_e2e_tests_nav_AF.outcome == 'failure'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          working-directory: VAMobile
+          api-level: 28
+          profile: pixel_6_pro
+          force-avd-creation: false
+          disable-animations: true
+          arch: x86_64
+          avd-name: Pixel_4_XL_API_28
+          script: yarn e2e:android-test /e2e/tests/Navigation.e2e AvailabilityFramework.e2e ${{matrix.testsuite}}.e2e --take-screenshots failing --updateSnapshot --headless
         
       - name: Upload e2e-junit
         if: failure() || success()
@@ -254,7 +252,7 @@ jobs:
         run: exit 1
   
   output-slack-results:
-    if: (!cancelled())
+    if: (!cancelled()) && github.event_name == 'schedule'
     needs: [matrix-e2e-android, start_slack_thread]
     runs-on: macos-latest-xl
     steps:
@@ -269,27 +267,20 @@ jobs:
         shell: bash
         run: |
           if grep -rq "<failure>" .; then
-            echo "found"
+            echo SLACK_THREAD_TS=${ts} >> $GITHUB_OUTPUT
+            ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \
+              -H 'Content-type: application/json' \
+              --data '{"channel":"'${{needs.start_slack_thread.outputs.channel_id}}'","thread_ts":"'${{needs.start_slack_thread.outputs.thread_ts}}'","text":"Failed! Please check workflow for results: https://github.com/department-of-veterans-affairs/va-mobile-app/actions"}' \
+              https://slack.com/api/chat.postMessage|
+              jq -r '.ts')
+            echo SLACK_THREAD_TS=${ts} >> $GITHUB_OUTPUT
           else
-            echo "not found"
+            ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \
+            -H 'Content-type: application/json' \
+            --data '{"channel":"'${{needs.start_slack_thread.outputs.channel_id}}'","thread_ts":"'${{needs.start_slack_thread.outputs.thread_ts}}'","text":"Success! All E2E tests have passed"}' \
+            https://slack.com/api/chat.postMessage|
+            jq -r '.ts')
           fi
-# list=$(find . -name "*e2e-junit")
-# echo "$list" 
-#if [[ "$list" == "" ]] then;
-#  ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \
-#  -H 'Content-type: application/json' \
-#  --data '{"channel":"'${{needs.start_slack_thread.outputs.channel_id}}'","thread_ts":"'${{needs.start_slack_thread.outputs.thread_ts}}'","text":"Success! All E2E tests have passed"}' \
-#  https://slack.com/api/chat.postMessage|
-#  jq -r '.ts')
-#else 
-#  echo SLACK_THREAD_TS=${ts} >> $GITHUB_OUTPUT
-#  ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \
-#    -H 'Content-type: application/json' \
-#    --data '{"channel":"'${{needs.start_slack_thread.outputs.channel_id}}'","thread_ts":"'${{needs.start_slack_thread.outputs.thread_ts}}'","text":"Failed! Please check workflow for results: https://github.com/department-of-veterans-affairs/va-mobile-app/actions"}' \
-#    https://slack.com/api/chat.postMessage|
-#    jq -r '.ts')
-#  echo SLACK_THREAD_TS=${ts} >> $GITHUB_OUTPUT
-#fi
     
   matrix-send_test_results_to_testrail:
     if: (!cancelled()) && github.event.inputs.run_testRail == 'true'

--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -133,7 +133,7 @@ jobs:
 
   matrix-e2e-android:
     if: (!cancelled()) && needs.output_detox_tests_to_run.outputs.output1 != ''
-    runs-on: ubuntu-latest
+    runs-on: macos-latest-xl
     needs: [start_slack_thread, output_detox_tests_to_run]
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -256,7 +256,7 @@ jobs:
   output-slack-results:
     if: (!cancelled())
     needs: [matrix-e2e-android, start_slack_thread]
-    runs-on: ubuntu-latest
+    runs-on: macos-latest-xl
     steps:
       - uses: actions/checkout@v3
         with:
@@ -266,8 +266,9 @@ jobs:
         with:
             path: VAMobile/artifacts
       - name: Inform Slack
+        shell: bash
         run: |
-          list=find . -name "*detox-artifacts*"
+          list=$(find /VAMobile/artifacts -name "*detox-artifacts*")
           echo "$list" 
 #if [[ "$list" == "" ]] then;
 #  ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \

--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -268,7 +268,7 @@ jobs:
       - name: Inform Slack
         shell: bash
         run: |
-          list=$(grep -r "<failure>" ./test_reports)
+          list=$(grep -r "<failure>" .)
           echo "$list"
 # list=$(find . -name "*e2e-junit")
 # echo "$list" 

--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -235,10 +235,17 @@ jobs:
       #     script: yarn e2e:android-test /e2e/tests/Navigation.e2e AvailabilityFramework.e2e ${{matrix.testsuite}}.e2e --take-screenshots failing --updateSnapshot --headless
         
       - name: Upload e2e-junit
-        if: failure() || success()
+        if: success()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{matrix.testsuite}}-e2e-junit
+          name: ${{matrix.testsuite}}-pass-e2e-junit
+          path: VAMobile/e2e/test_reports/e2e-junit.xml
+      
+      - name: Upload failure e2e-junit
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{matrix.testsuite}}-failure-e2e-junit
           path: VAMobile/e2e/test_reports/e2e-junit.xml
 
       - name: Upload artifacts on failure
@@ -264,11 +271,11 @@ jobs:
       - name: Download results
         uses: actions/download-artifact@v4
         with:
-            path: VAMobile/artifacts
+          pattern: *-failure-e2e-junit
       - name: Inform Slack
         shell: bash
         run: |
-          list=$(find . -name "*detox-artifacts*")
+          list=$(find . -name "*failure*")
           echo "$list" 
 #if [[ "$list" == "" ]] then;
 #  ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \

--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -271,6 +271,9 @@ jobs:
     needs: [matrix-e2e-android, start_slack_thread]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
       - name: Download results
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -268,8 +268,12 @@ jobs:
       - name: Inform Slack
         shell: bash
         run: |
-          list=$(grep -r "<failure>" .)
-          echo "$list"
+          list="$(grep -r "<failure>" .)"
+          if [[ "$list" ]] then;
+            echo "found"
+          else
+            echo "notFound"
+          fi
 # list=$(find . -name "*e2e-junit")
 # echo "$list" 
 #if [[ "$list" == "" ]] then;

--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -267,7 +267,7 @@ jobs:
             path: VAMobile/artifacts
       - name: Inform Slack
         run: |
-          list=find ./VAMobile/artifacts -name "*detox-artifacts*"
+          list=find . -name "*detox-artifacts*"
           echo "$list" 
 #if [[ "$list" == "" ]] then;
 #  ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \

--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -139,6 +139,8 @@ jobs:
       fail-fast: false
       matrix:
         testsuite: ${{fromJson(needs.output_detox_tests_to_run.outputs.output1)}}
+    outputs: 
+      output1: ${{ steps.post_failure.outputs.test_failure }}
 
     steps:
       - uses: actions/checkout@v3
@@ -219,19 +221,6 @@ jobs:
           avd-name: Pixel_4_XL_API_28
           script: yarn e2e:android-test /e2e/tests/Navigation.e2e AvailabilityFramework.e2e ${{matrix.testsuite}}.e2e --take-screenshots failing --updateSnapshot --headless
 
-      - name: Clear jest cache
-        if: failure() && steps.run_e2e_tests_nav_AF.outcome == 'failure'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          working-directory: VAMobile
-          api-level: 28
-          profile: pixel_6_pro
-          force-avd-creation: false
-          disable-animations: true
-          arch: x86_64
-          avd-name: Pixel_4_XL_API_28
-          script: yarn jest:clear
-
       - name: Run e2e tests for Android
         if: failure() && steps.run_e2e_tests_nav_AF.outcome == 'failure'
         uses: reactivecircus/android-emulator-runner@v2
@@ -252,27 +241,19 @@ jobs:
           name: ${{matrix.testsuite}}-e2e-junit
           path: VAMobile/e2e/test_reports/e2e-junit.xml
 
-      - name: Inform Slack of Failure
+      - name: Create artifact
+        if: steps.run_e2e_tests.outcome == 'failure'
+        run: |
+          echo > VAMobile/artifacts/failure.txt
+      
+      - name: Output test failure
         id: post_failure
-        if: steps.run_e2e_tests.outcome == 'failure' && github.event_name == 'schedule'
-        run: |
-          ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \
-            -H 'Content-type: application/json' \
-            --data '{"channel":"'${{needs.start_slack_thread.outputs.channel_id}}'","thread_ts":"'${{needs.start_slack_thread.outputs.thread_ts}}'","text":"Failed! Please check workflow for results: https://github.com/department-of-veterans-affairs/va-mobile-app/actions"}' \
-            https://slack.com/api/chat.postMessage|
-            jq -r '.ts')
-          echo SLACK_THREAD_TS=${ts} >> $GITHUB_OUTPUT
-
-      - name: Inform Slack of success
-        id: post_success
-        if: steps.run_e2e_tests.outcome == 'success' && github.event_name == 'schedule'
-        run: |
-          ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \
-            -H 'Content-type: application/json' \
-            --data '{"channel":"'${{needs.start_slack_thread.outputs.channel_id}}'","thread_ts":"'${{needs.start_slack_thread.outputs.thread_ts}}'","text":"Success! All E2E tests have passed"}' \
-            https://slack.com/api/chat.postMessage|
-            jq -r '.ts')
-          echo SLACK_THREAD_TS=${ts} >> $GITHUB_OUTPUT
+        if: steps.run_e2e_tests.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          overwrite: true
+          path: VAMobile/artifacts/failure.txt
+          retention-days: 1
 
       - name: Upload artifacts on failure
         if: failure() && steps.run_e2e_tests.outcome == 'failure'
@@ -284,7 +265,36 @@ jobs:
       - name: Fail workflow if needed(View e2e step for details)
         if: steps.run_e2e_tests.outcome == 'failure'
         run: exit 1
-
+  
+  output-slack-results:
+    if: (!cancelled())
+    needs: [matrix-e2e-android, start_slack_thread]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download results
+        uses: actions/download-artifact@v4
+        with:
+            path: VAMobile/artifacts
+      - name: Inform Slack
+        run: |
+          list=find . -maxdepth 1 -name "VAMobile/artifacts/failure.txt"
+          echo "$list" 
+#if [[ "$list" == "" ]] then;
+#  ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \
+#  -H 'Content-type: application/json' \
+#  --data '{"channel":"'${{needs.start_slack_thread.outputs.channel_id}}'","thread_ts":"'${{needs.start_slack_thread.outputs.thread_ts}}'","text":"Success! All E2E tests have passed"}' \
+#  https://slack.com/api/chat.postMessage|
+#  jq -r '.ts')
+#else 
+#  echo SLACK_THREAD_TS=${ts} >> $GITHUB_OUTPUT
+#  ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \
+#    -H 'Content-type: application/json' \
+#    --data '{"channel":"'${{needs.start_slack_thread.outputs.channel_id}}'","thread_ts":"'${{needs.start_slack_thread.outputs.thread_ts}}'","text":"Failed! Please check workflow for results: https://github.com/department-of-veterans-affairs/va-mobile-app/actions"}' \
+#    https://slack.com/api/chat.postMessage|
+#    jq -r '.ts')
+#  echo SLACK_THREAD_TS=${ts} >> $GITHUB_OUTPUT
+#fi
+    
   matrix-send_test_results_to_testrail:
     if: (!cancelled()) && github.event.inputs.run_testRail == 'true'
     needs: [matrix-e2e-android, output_detox_tests_to_run]

--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -268,10 +268,10 @@ jobs:
       - name: Inform Slack
         shell: bash
         run: |
-          if [[ $(grep -L -r "<failure>" .) ]]; then
-            echo "not found"
-          else
+          if grep -rq "<failure>" .; then
             echo "found"
+          else
+            echo "not found"
           fi
 # list=$(find . -name "*e2e-junit")
 # echo "$list" 

--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -240,12 +240,11 @@ jobs:
           path: VAMobile/e2e/test_reports/e2e-junit.xml
 
       - name: Upload artifacts on failure
-        if: failure()
+        if: failure() && steps.run_e2e_tests.outcome == 'failure'
         uses: actions/upload-artifact@v4
         with:
           name: detox-artifacts-${{ runner.os }}-${{ github.run_id }}
           path: VAMobile/artifacts
-          retention-days: 3
 
       - name: Fail workflow if needed(View e2e step for details)
         if: steps.run_e2e_tests.outcome == 'failure'

--- a/.github/workflows/e2e_android.yml
+++ b/.github/workflows/e2e_android.yml
@@ -242,13 +242,13 @@ jobs:
           path: VAMobile/e2e/test_reports/e2e-junit.xml
 
       - name: Create artifact
-        if: steps.run_e2e_tests.outcome == 'failure'
+        if: failure() && steps.run_e2e_tests_nav_AF.outcome == 'failure'
         run: |
           echo > VAMobile/artifacts/failure.txt
       
       - name: Output test failure
         id: post_failure
-        if: steps.run_e2e_tests.outcome == 'failure'
+        if: failure() && steps.run_e2e_tests_nav_AF.outcome == 'failure'
         uses: actions/upload-artifact@v4
         with:
           overwrite: true
@@ -280,7 +280,7 @@ jobs:
             path: VAMobile/artifacts
       - name: Inform Slack
         run: |
-          list=find . -maxdepth 1 -name "VAMobile/artifacts/failure.txt"
+          list=find ./VAMobile/artifacts -name "failure.txt"
           echo "$list" 
 #if [[ "$list" == "" ]] then;
 #  ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \

--- a/.github/workflows/e2e_ios.yml
+++ b/.github/workflows/e2e_ios.yml
@@ -223,36 +223,36 @@ jobs:
         if: steps.run_e2e_tests.outcome == 'failure'
         run: exit 1
   
-  output-slack-results:
-    if: (!cancelled()) && github.event_name == 'schedule'
-    needs: [matrix-e2e-ios, start_slack_thread]
-    runs-on: macos-latest-xl
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.ref }}
-      - name: Download results
-        uses: actions/download-artifact@v4
-        with:
-            path: VAMobile/e2e/test_reports
-      - name: Inform Slack
-        shell: bash
-        run: |
-          if grep -rq "<failure>" .; then
-            echo SLACK_THREAD_TS=${ts} >> $GITHUB_OUTPUT
-            ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \
-              -H 'Content-type: application/json' \
-              --data '{"channel":"'${{needs.start_slack_thread.outputs.channel_id}}'","thread_ts":"'${{needs.start_slack_thread.outputs.thread_ts}}'","text":"Failed! Please check workflow for results: https://github.com/department-of-veterans-affairs/va-mobile-app/actions"}' \
-              https://slack.com/api/chat.postMessage|
-              jq -r '.ts')
-            echo SLACK_THREAD_TS=${ts} >> $GITHUB_OUTPUT
-          else
-            ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \
-            -H 'Content-type: application/json' \
-            --data '{"channel":"'${{needs.start_slack_thread.outputs.channel_id}}'","thread_ts":"'${{needs.start_slack_thread.outputs.thread_ts}}'","text":"Success! All E2E tests have passed"}' \
-            https://slack.com/api/chat.postMessage|
-            jq -r '.ts')
-          fi
+  # output-slack-results:
+  #   if: (!cancelled()) && github.event_name == 'schedule'
+  #   needs: [matrix-e2e-ios, start_slack_thread]
+  #   runs-on: macos-latest-xl
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         ref: ${{ github.ref }}
+  #     - name: Download results
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #           path: VAMobile/e2e/test_reports
+  #     - name: Inform Slack
+  #       shell: bash
+  #       run: |
+  #         if grep -rq "<failure>" .; then
+  #           echo SLACK_THREAD_TS=${ts} >> $GITHUB_OUTPUT
+  #           ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \
+  #             -H 'Content-type: application/json' \
+  #             --data '{"channel":"'${{needs.start_slack_thread.outputs.channel_id}}'","thread_ts":"'${{needs.start_slack_thread.outputs.thread_ts}}'","text":"Failed! Please check workflow for results: https://github.com/department-of-veterans-affairs/va-mobile-app/actions"}' \
+  #             https://slack.com/api/chat.postMessage|
+  #             jq -r '.ts')
+  #           echo SLACK_THREAD_TS=${ts} >> $GITHUB_OUTPUT
+  #         else
+  #           ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \
+  #           -H 'Content-type: application/json' \
+  #           --data '{"channel":"'${{needs.start_slack_thread.outputs.channel_id}}'","thread_ts":"'${{needs.start_slack_thread.outputs.thread_ts}}'","text":"Success! All E2E tests have passed"}' \
+  #           https://slack.com/api/chat.postMessage|
+  #           jq -r '.ts')
+  #         fi
 
   matrix-send_test_results_to_testrail:
     if: (!cancelled()) && github.event.inputs.run_testRail == 'true'

--- a/.github/workflows/e2e_ios.yml
+++ b/.github/workflows/e2e_ios.yml
@@ -212,28 +212,6 @@ jobs:
             name: ${{matrix.testsuite}}-e2e-junit
             path: VAMobile/e2e/test_reports/e2e-junit.xml
 
-      - name: Inform Slack of Failure
-        id: post_failure
-        if: steps.run_e2e_tests.outcome == 'failure' && github.event_name == 'schedule'
-        run: |
-          ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \
-            -H 'Content-type: application/json' \
-            --data '{"channel":"'${{needs.start_slack_thread.outputs.channel_id}}'","thread_ts":"'${{needs.start_slack_thread.outputs.thread_ts}}'","text":"Failed! Please check workflow for results: https://github.com/department-of-veterans-affairs/va-mobile-app/actions"}' \
-            https://slack.com/api/chat.postMessage|
-            jq -r '.ts')
-          echo SLACK_THREAD_TS=${ts} >> $GITHUB_OUTPUT
-
-      - name: Inform Slack of success
-        id: post_success
-        if: steps.run_e2e_tests.outcome == 'success' && github.event_name == 'schedule'
-        run: |
-          ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \
-            -H 'Content-type: application/json' \
-            --data '{"channel":"'${{needs.start_slack_thread.outputs.channel_id}}'","thread_ts":"'${{needs.start_slack_thread.outputs.thread_ts}}'","text":"Success! All E2E tests have passed"}' \
-            https://slack.com/api/chat.postMessage|
-            jq -r '.ts')
-          echo SLACK_THREAD_TS=${ts} >> $GITHUB_OUTPUT
-
       - name: Upload artifacts on failure
         if: failure() && (steps.run_e2e_tests.outcome == 'failure' || steps.rerun_e2e_tests.outcome == 'failure')
         uses: actions/upload-artifact@v4
@@ -244,6 +222,37 @@ jobs:
       - name: Fail workflow if needed(View e2e step for details)
         if: steps.run_e2e_tests.outcome == 'failure'
         run: exit 1
+  
+  output-slack-results:
+    if: (!cancelled()) && github.event_name == 'schedule'
+    needs: [matrix-e2e-ios, start_slack_thread]
+    runs-on: macos-latest-xl
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+      - name: Download results
+        uses: actions/download-artifact@v4
+        with:
+            path: VAMobile/e2e/test_reports
+      - name: Inform Slack
+        shell: bash
+        run: |
+          if grep -rq "<failure>" .; then
+            echo SLACK_THREAD_TS=${ts} >> $GITHUB_OUTPUT
+            ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \
+              -H 'Content-type: application/json' \
+              --data '{"channel":"'${{needs.start_slack_thread.outputs.channel_id}}'","thread_ts":"'${{needs.start_slack_thread.outputs.thread_ts}}'","text":"Failed! Please check workflow for results: https://github.com/department-of-veterans-affairs/va-mobile-app/actions"}' \
+              https://slack.com/api/chat.postMessage|
+              jq -r '.ts')
+            echo SLACK_THREAD_TS=${ts} >> $GITHUB_OUTPUT
+          else
+            ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \
+            -H 'Content-type: application/json' \
+            --data '{"channel":"'${{needs.start_slack_thread.outputs.channel_id}}'","thread_ts":"'${{needs.start_slack_thread.outputs.thread_ts}}'","text":"Success! All E2E tests have passed"}' \
+            https://slack.com/api/chat.postMessage|
+            jq -r '.ts')
+          fi
 
   matrix-send_test_results_to_testrail:
     if: (!cancelled()) && github.event.inputs.run_testRail == 'true'

--- a/.github/workflows/e2e_ios.yml
+++ b/.github/workflows/e2e_ios.yml
@@ -223,36 +223,36 @@ jobs:
         if: steps.run_e2e_tests.outcome == 'failure'
         run: exit 1
   
-  # output-slack-results:
-  #   if: (!cancelled()) && github.event_name == 'schedule'
-  #   needs: [matrix-e2e-ios, start_slack_thread]
-  #   runs-on: macos-latest-xl
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         ref: ${{ github.ref }}
-  #     - name: Download results
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #           path: VAMobile/e2e/test_reports
-  #     - name: Inform Slack
-  #       shell: bash
-  #       run: |
-  #         if grep -rq "<failure>" .; then
-  #           echo SLACK_THREAD_TS=${ts} >> $GITHUB_OUTPUT
-  #           ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \
-  #             -H 'Content-type: application/json' \
-  #             --data '{"channel":"'${{needs.start_slack_thread.outputs.channel_id}}'","thread_ts":"'${{needs.start_slack_thread.outputs.thread_ts}}'","text":"Failed! Please check workflow for results: https://github.com/department-of-veterans-affairs/va-mobile-app/actions"}' \
-  #             https://slack.com/api/chat.postMessage|
-  #             jq -r '.ts')
-  #           echo SLACK_THREAD_TS=${ts} >> $GITHUB_OUTPUT
-  #         else
-  #           ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \
-  #           -H 'Content-type: application/json' \
-  #           --data '{"channel":"'${{needs.start_slack_thread.outputs.channel_id}}'","thread_ts":"'${{needs.start_slack_thread.outputs.thread_ts}}'","text":"Success! All E2E tests have passed"}' \
-  #           https://slack.com/api/chat.postMessage|
-  #           jq -r '.ts')
-  #         fi
+  output-slack-results:
+    if: (!cancelled()) && github.event_name == 'schedule'
+    needs: [matrix-e2e-ios, start_slack_thread]
+    runs-on: macos-latest-xl
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
+      - name: Download results
+        uses: actions/download-artifact@v4
+        with:
+            path: VAMobile/e2e/test_reports
+      - name: Inform Slack
+        shell: bash
+        run: |
+          if grep -rq "<failure>" .; then
+            echo SLACK_THREAD_TS=${ts} >> $GITHUB_OUTPUT
+            ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \
+              -H 'Content-type: application/json' \
+              --data '{"channel":"'${{needs.start_slack_thread.outputs.channel_id}}'","thread_ts":"'${{needs.start_slack_thread.outputs.thread_ts}}'","text":"Failed! Please check workflow for results: https://github.com/department-of-veterans-affairs/va-mobile-app/actions"}' \
+              https://slack.com/api/chat.postMessage|
+              jq -r '.ts')
+            echo SLACK_THREAD_TS=${ts} >> $GITHUB_OUTPUT
+          else
+            ts=$(curl -X POST -H 'Authorization: Bearer '"$SLACK_API_TOKEN"' ' \
+            -H 'Content-type: application/json' \
+            --data '{"channel":"'${{needs.start_slack_thread.outputs.channel_id}}'","thread_ts":"'${{needs.start_slack_thread.outputs.thread_ts}}'","text":"Success! All E2E tests have passed"}' \
+            https://slack.com/api/chat.postMessage|
+            jq -r '.ts')
+          fi
 
   matrix-send_test_results_to_testrail:
     if: (!cancelled()) && github.event.inputs.run_testRail == 'true'

--- a/VAMobile/e2e/tests/Onboarding.e2e.ts
+++ b/VAMobile/e2e/tests/Onboarding.e2e.ts
@@ -31,7 +31,7 @@ describe('Onboarding Screen', () => {
   it('should tap next and show the manage your health care content', async () => {
     await element(by.text('Next')).tap()
     await expect(element(by.text('Manage your health care')))
-    await expect(element(by.text('Use our health care tools to manage tasks like these:'))).toExist()
+    await expect(element(by.text('Use our health care tool to manage tasks like these:'))).toExist()
     await expect(element(by.text('Refill your prescriptions'))).toExist()
     await expect(element(by.text('Communicate with your health care team'))).toExist()
     await expect(element(by.text('Review your appointments'))).toExist()

--- a/VAMobile/e2e/tests/Onboarding.e2e.ts
+++ b/VAMobile/e2e/tests/Onboarding.e2e.ts
@@ -31,7 +31,7 @@ describe('Onboarding Screen', () => {
   it('should tap next and show the manage your health care content', async () => {
     await element(by.text('Next')).tap()
     await expect(element(by.text('Manage your health care')))
-    await expect(element(by.text('Use our health care tool to manage tasks like these:'))).toExist()
+    await expect(element(by.text('Use our health care tools to manage tasks like these:'))).toExist()
     await expect(element(by.text('Refill your prescriptions'))).toExist()
     await expect(element(by.text('Communicate with your health care team'))).toExist()
     await expect(element(by.text('Review your appointments'))).toExist()


### PR DESCRIPTION
## Description of Change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, 
need to know about this PR in order to understand why this PR was created? This could include dependencies 
introduced, changes in behavior, pointers to more detailed documentation. The description should be more 
than a link to an issue.  -->
Changed the logic of the e2e GitHub Actions tests so the slack pass/fail message only appears once.

## Screenshots/Video
<!-- Add screenshots or video as needed. Before/after if changes are to be compared by reviewers.
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Toggle: <details><summary></summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>
-->

## Testing
<!-- What testing was done to verify the changes (local/unit)? What testing remains? Note edge cases, or special
situations that could not be tested during development. -->

- [ ] Tested on iOS <!-- simulator is fine -->
- [ ] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
<!-- What should reviewers look for? Copy/paste Acceptance Criteria from ticket -->

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [ ] PR is connected to issue(s)
- [ ] Tests are included to cover this change (when possible)
- [ ] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [ ] No secrets or API keys are checked in
- [ ] All imports are absolute (no relative imports)
- [ ] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
