### PR TITLE
bug/9004-ApostropheSecureMessagingFix

### DIFF
--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/ViewMessage/CollapsibleMessage.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/ViewMessage/CollapsibleMessage.tsx
@@ -184,7 +184,7 @@ function CollapsibleMessage({ message, isInitialMessage, collapsibleMessageRef }
     return (
       <Box>
         <TextView mt={condensedMarginBetween} variant="MobileBody" numberOfLines={2}>
-          {body?.trimStart()}
+          {fixSpecialCharacters(body || '').trimStart()}
         </TextView>
       </Box>
     )

--- a/VAMobile/src/utils/jsonFormatting.ts
+++ b/VAMobile/src/utils/jsonFormatting.ts
@@ -23,4 +23,7 @@ export const fixSpecialCharacters = (text: string): string => {
     .replace(/&amp;/g, '&')
     .replace(/&ldquo;/g, '"')
     .replace(/&rsquo;/g, "'")
+    .replace(/&rdquo;/g, '"')
+    .replace(/&lsquo;/g, "'")
+    .replace(/&#39;/g, "'")
 }


### PR DESCRIPTION
## Description of Change
Added these 3 cases to fix special characters

.replace(/&rdquo;/g, '"')
    .replace(/&lsquo;/g, "'")
    .replace(/&#39;/g, "'")

## Screenshots/Video
N/A

## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
don&#39;t should be don't

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
