### PR TITLE
fixed

### DIFF
--- a/VAMobile/src/components/VABulletList.tsx
+++ b/VAMobile/src/components/VABulletList.tsx
@@ -51,7 +51,7 @@ export type VABulletListProps = {
 /**
  * Displays the list of text as a bulleted list
  */
-const VABulletList: FC<VABulletListProps> = ({ listOfText }, paragraphSpacing) => {
+const VABulletList: FC<VABulletListProps> = ({ listOfText, paragraphSpacing }) => {
   const launchExternalLink = useExternalLink()
   const theme = useTheme()
 

--- a/VAMobile/src/components/WhatsNew.tsx
+++ b/VAMobile/src/components/WhatsNew.tsx
@@ -106,7 +106,7 @@ export const WhatsNew = () => {
           <TextView accessibilityLabel={bodyA11yLabel}>{body}</TextView>
           {bullets.length ? (
             <Box mt={theme.dimensions.standardMarginBetween}>
-              <VABulletList listOfText={bullets} />
+              <VABulletList listOfText={bullets} paragraphSpacing={true} />
             </Box>
           ) : undefined}
         </Box>

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/AppealDetailsScreen/AppealStatus/AppealCurrentStatus/AppealCurrentStatus.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/AppealDetailsScreen/AppealStatus/AppealCurrentStatus/AppealCurrentStatus.tsx
@@ -353,7 +353,7 @@ function AppealCurrentStatus({ status, aoj, appealType, docketName, programArea 
               {details[0]}
             </TextView>
             <Box mt={marginTop}>
-              <VABulletList listOfText={[details[1], details[2]]} />
+              <VABulletList listOfText={[details[1], details[2]]} paragraphSpacing={true} />
             </Box>
           </Box>
         )
@@ -378,7 +378,7 @@ function AppealCurrentStatus({ status, aoj, appealType, docketName, programArea 
               {details[1]}
             </TextView>
             <Box mt={marginTop}>
-              <VABulletList listOfText={bulletList} />
+              <VABulletList listOfText={bulletList} paragraphSpacing={true} />
             </Box>
           </Box>
         )

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/AppealDetailsScreen/AppealStatus/AppealDecision/AppealDecision.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/AppealDetailsScreen/AppealStatus/AppealDecision/AppealDecision.tsx
@@ -56,7 +56,7 @@ function AppealDecision({ issues, aoj, ama, boardDecision }: AppealDecisionProps
       <Box mt={theme.dimensions.standardMarginBetween}>
         <TextView variant="MobileBodyBold">{header}</TextView>
         <TextView variant="MobileBody">{subText}</TextView>
-        <VABulletList listOfText={getIssuesListOfText(specificIssues)} />
+        <VABulletList listOfText={getIssuesListOfText(specificIssues)} paragraphSpacing={true} />
       </Box>
     )
   }

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/AskForClaimDecision/AskForClaimDecision.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/AskForClaimDecision/AskForClaimDecision.tsx
@@ -161,7 +161,7 @@ function AskForClaimDecision({ navigation, route }: AskForClaimDecisionProps) {
             <TextView variant="MobileBody" mb={standardMarginBetween}>
               {t('askForClaimDecision.takingFull30Days')}
             </TextView>
-            <VABulletList listOfText={bulletedListOfText} />
+            <VABulletList listOfText={bulletedListOfText} paragraphSpacing={true} />
           </TextArea>
           <Box mx={gutter}>
             <Box my={standardMarginBetween}>

--- a/VAMobile/src/screens/HealthScreen/HealthHelp/HealthHelp.tsx
+++ b/VAMobile/src/screens/HealthScreen/HealthHelp/HealthHelp.tsx
@@ -40,7 +40,7 @@ function HealthHelp({}: HealthHelpProps) {
       <TextView variant="cernerPanelSubtext" mb={theme.dimensions.standardMarginBetween}>
         {t('healthHelp.manageHealthCare.multi.both')}
       </TextView>
-      <VABulletList listOfText={bullets} />
+      <VABulletList listOfText={bullets} paragraphSpacing={true} />
       <TextView variant="cernerPanelSubtext" mb={theme.dimensions.condensedMarginBetween}>
         {t('healthHelp.goToPortal.multi.both')}
       </TextView>

--- a/VAMobile/src/screens/HealthScreen/Pharmacy/PrescriptionDetails/PrescriptionsDetailsBanner.tsx
+++ b/VAMobile/src/screens/HealthScreen/Pharmacy/PrescriptionDetails/PrescriptionsDetailsBanner.tsx
@@ -51,7 +51,7 @@ function PrescriptionsDetailsBanner() {
           {t('prescription.details.banner.body2')}
         </TextView>
         <Box>
-          <VABulletList listOfText={bullets} />
+          <VABulletList listOfText={bullets} paragraphSpacing={true} />
         </Box>
         <ClickToCallPhoneNumber
           phone={t('5418307563')}

--- a/VAMobile/src/screens/HealthScreen/Pharmacy/PrescriptionHelp/PrescriptionHelp.tsx
+++ b/VAMobile/src/screens/HealthScreen/Pharmacy/PrescriptionHelp/PrescriptionHelp.tsx
@@ -45,7 +45,7 @@ function PrescriptionHelp({}: PrescriptionHelpProps) {
         <TextView mt={condensedMarginBetween} variant="MobileBody" paragraphSpacing={true}>
           {t('prescription.help.listHeader')}
         </TextView>
-        <VABulletList listOfText={medicationNoIncludedList} />
+        <VABulletList listOfText={medicationNoIncludedList} paragraphSpacing={true} />
         <TextView variant="MobileBody" accessibilityLabel={a11yLabelVA(t('prescription.help.footer'))}>
           {t('prescription.help.footer')}
         </TextView>

--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/CernerAlertSM/CernerAlertSM.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/CernerAlertSM/CernerAlertSM.tsx
@@ -67,7 +67,7 @@ function CernerAlertSM() {
         <TextView variant="MobileBody" paragraphSpacing={true}>
           {intro}
         </TextView>
-        {hasMultipleFacilities && <VABulletList listOfText={bullets} />}
+        {hasMultipleFacilities && <VABulletList listOfText={bullets} paragraphSpacing={true} />}
         <TextView variant="MobileBody" accessibilityLabel={outroA11y} paragraphSpacing={true}>
           {outro}
         </TextView>

--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/ReplyHelp/ReplyHelp.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/ReplyHelp/ReplyHelp.tsx
@@ -45,6 +45,7 @@ function ReplyHelp() {
               a11yLabel: t('secureMessaging.replyHelp.ifYoureInCrisis') + t('secureMessaging.replyHelp.connectWithOur'),
             },
           ]}
+          paragraphSpacing={true}
         />
 
         <VeteransCrisisLineNumbers />
@@ -58,6 +59,7 @@ function ReplyHelp() {
                 a11yLabel: t('secureMessaging.replyHelp.ifYouThink') + t('secureMessaging.replyHelp.call911OrGoTo'),
               },
             ]}
+            paragraphSpacing={true}
           />
         </Box>
         <ClickToCallPhoneNumber

--- a/VAMobile/src/screens/HomeScreen/ProfileScreen/SettingsScreen/InAppRecruitmentScreen/InAppRecruitmentScreen.tsx
+++ b/VAMobile/src/screens/HomeScreen/ProfileScreen/SettingsScreen/InAppRecruitmentScreen/InAppRecruitmentScreen.tsx
@@ -75,6 +75,7 @@ function InAppRecruitmentScreen({ navigation }: InAppRecruitmentScreenProps) {
               a11yLabel: a11yLabelVA(t('inAppRecruitment.makeAppBetter.bullet.3')),
             },
           ]}
+          paragraphSpacing={true}
         />
         <Button onPress={onPress} label={t('inAppRecruitment.goToQuestionnaire')} />
         <Box mt={theme.dimensions.standardMarginBetween}>

--- a/VAMobile/src/screens/OnboardingCarousel/GenericOnboarding/GenericOnboarding.tsx
+++ b/VAMobile/src/screens/OnboardingCarousel/GenericOnboarding/GenericOnboarding.tsx
@@ -71,7 +71,7 @@ function GenericOnboarding({
         )}
         {listOfText && (
           <Box mt={theme.dimensions.standardMarginBetween} ml={theme.dimensions.gutter}>
-            <VABulletList listOfText={listOfText} />
+            <VABulletList listOfText={listOfText} paragraphSpacing={true} />
           </Box>
         )}
       </Box>

--- a/VAMobile/src/screens/auth/LoaGate/LoaGate.tsx
+++ b/VAMobile/src/screens/auth/LoaGate/LoaGate.tsx
@@ -66,7 +66,7 @@ function LoaGate({}: LoaGateProps) {
             <TextView {...bodyTextProps}>{t('loaGate.readMore.itemTwo.OfferProof')}</TextView>
           </Box>
           <Box mt={theme.dimensions.standardMarginBetween}>
-            <VABulletList listOfText={[bulletOne, { text: t('loaGate.readMore.bulletTwo') }]} />
+            <VABulletList listOfText={[bulletOne, { text: t('loaGate.readMore.bulletTwo') }]} paragraphSpacing={true} />
           </Box>
         </CollapsibleView>
         <Box mt={theme.dimensions.textAndButtonLargeMargin}>


### PR DESCRIPTION
## Description of Change
Was found that SM save message alert and appeal issues had incorrect applied paragraph spacing, fixed component props and then added paragraph spacing that needed to be re-added to all the other lists since they needed to maintain paragraph spacing

## Screenshots/Video
<img width="474" alt="Screenshot 2024-07-16 at 2 47 16 PM" src="https://github.com/user-attachments/assets/66b6f370-df97-4ceb-bee0-fba4d7718a32">
<img width="474" alt="Screenshot 2024-07-16 at 2 47 31 PM" src="https://github.com/user-attachments/assets/9d02f7e2-af9f-45eb-b2c5-d4a776a9b65c">


## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
 think this was brought on by WCAG paragraph spacing but maybe not. There is a too much spacing after a bulleted list in some cases. This includes:

Messages > The we need more information bullet list when saving a messaging, saving a reply, saving a draft etc.
Claims > Claims History > Appeal Details > Issues Segment > The currently on appeal bullet list

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
