### PR TITLE
bug/9187-SMEditDraftNullCrashesFix

### DIFF
--- a/VAMobile/src/api/types/SecureMessagingData.ts
+++ b/VAMobile/src/api/types/SecureMessagingData.ts
@@ -20,7 +20,7 @@ export type SecureMessagingMessageAttributes = {
   sentDate: string
   senderId: number
   senderName: string
-  recipientId: number
+  recipientId?: number
   recipientName: string
   readReceipt?: string
 }

--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/EditDraft/EditDraft.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/EditDraft/EditDraft.tsx
@@ -150,7 +150,7 @@ function EditDraft({ navigation, route }: EditDraftProps) {
   )
   const replyDisabled = isReplyDraft && !hasRecentMessages
 
-  const [to, setTo] = useState(message?.recipientId?.toString() || '')
+  const [to, setTo] = useState((message?.recipientId || '').toString())
   const [category, setCategory] = useState<CategoryTypes>(message?.category || '')
   const [subject, setSubject] = useState(message?.subject || '')
   const [attachmentsList, addAttachment, removeAttachment] = useAttachments()
@@ -183,7 +183,7 @@ function EditDraft({ navigation, route }: EditDraftProps) {
       setBody(message?.body || '')
       setCategory(message?.category || '')
       setSubject(message?.subject || '')
-      setTo(message?.recipientId?.toString() || '')
+      setTo((message?.recipientId || '').toString())
     }
   }, [loadingMessage, messageFetched, message.body, message.category, message.subject, message.recipientId])
 
@@ -238,7 +238,7 @@ function EditDraft({ navigation, route }: EditDraftProps) {
       return message?.body !== body
     } else {
       return (
-        message?.recipientId?.toString() !== to ||
+        (message?.recipientId || '').toString() !== to ||
         message?.category !== category ||
         message?.subject !== subject ||
         message?.body !== body

--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/EditDraft/EditDraft.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/EditDraft/EditDraft.tsx
@@ -183,7 +183,7 @@ function EditDraft({ navigation, route }: EditDraftProps) {
       setBody(message?.body || '')
       setCategory(message?.category || '')
       setSubject(message?.subject || '')
-      setTo(message?.recipientId.toString() || '')
+      setTo(message?.recipientId?.toString() || '')
     }
   }, [loadingMessage, messageFetched, message.body, message.category, message.subject, message.recipientId])
 


### PR DESCRIPTION
## Description of Change
Added a fix for recipientID being null as a result of 502 and 504 errors from upstream. Not sure why that caused the crash, but the only toString function that didn't have a ? after recipientID is in the useEffect and would cause it to possibly crash. Not sure how this can officially be tested though

## Screenshots/Video
N/A

## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
Shouldn't crash with 502s or 504s on the edit draft screen

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
