### PR TITLE
bug/9065-PaymentHistoryAPICalledTwice

### DIFF
--- a/VAMobile/src/api/types/PaymentData.ts
+++ b/VAMobile/src/api/types/PaymentData.ts
@@ -3,7 +3,7 @@ export type PaymentsGetData = {
   paymentsByDate?: PaymentsByDate
   meta: {
     pagination?: PaymentsMetaPagination
-    availableYears: Array<string> | null
+    availableYears: Array<number> | null
   }
   links: {
     self: string | null


### PR DESCRIPTION
## Description of Change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, 
need to know about this PR in order to understand why this PR was created? This could include dependencies 
introduced, changes in behavior, pointers to more detailed documentation. The description should be more 
than a link to an issue.  -->
Prevents the payment history endpoint from being called twice when the Payment history screen is mounted. Also updates the incorrect data type for `availableYears` in the `meta` field of the payment history endpoint data.

## Screenshots/Video
<!-- Add screenshots or video as needed. Before/after if changes are to be compared by reviewers.
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Toggle: <details><summary></summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>
-->
N/A

## Testing
<!-- What testing was done to verify the changes (local/unit)? What testing remains? Note edge cases, or special
situations that could not be tested during development. -->
Tested locally in demo mode and staging.

- [x] Tested on iOS <!-- simulator is fine -->
- [ ] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
<!-- What should reviewers look for? Copy/paste Acceptance Criteria from ticket -->
Payment history endpoint `mobile/v0/payment-history` isn't called twice on screen mount.

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [ ] PR is connected to issue(s)
- [ ] Tests are included to cover this change (when possible)
- [ ] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [ ] No secrets or API keys are checked in
- [ ] All imports are absolute (no relative imports)
- [ ] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
