### PR TITLE
bug/9266-JSONParseError

### DIFF
--- a/VAMobile/src/store/api/api.test.ts
+++ b/VAMobile/src/store/api/api.test.ts
@@ -82,13 +82,6 @@ context('api', () => {
     fetch.mockResolvedValue(response)
     const formData = new FormData()
 
-    it("returns undefined when the Content-Type of a successful response is not 'application/json'", async () => {
-      const responseBlob = new Blob(['Success'])
-      const response = new Response(responseBlob, { status: 200, headers: { 'Content-Type': 'text/html' } })
-      fetch.mockResolvedValue(response)
-      const result = await get<Types.UserData>('/foo')
-      expect(result).toEqual(undefined)
-    })
     const result = await post('/foo', { formData }, contentTypes.multipart)
 
     const headers = expect.objectContaining({ 'Content-Type': contentTypes.multipart })
@@ -100,5 +93,13 @@ context('api', () => {
       expect.objectContaining({ method: 'POST', body, headers }),
     )
     expect(result).toEqual(expect.objectContaining({ res: 'response' }))
+  })
+
+  it("returns undefined when the Content-Type of a successful response is not 'application/json'", async () => {
+    const responseBlob = new Blob(['Success'])
+    const response = new Response(responseBlob, { status: 200, headers: { 'Content-Type': 'text/html' } })
+    fetch.mockResolvedValue(response)
+    const result = await get<Types.UserData>('/foo')
+    expect(result).toEqual(undefined)
   })
 })

--- a/VAMobile/src/store/api/api.test.ts
+++ b/VAMobile/src/store/api/api.test.ts
@@ -13,13 +13,23 @@ jest.mock('store/slices', () => {
 
 context('api', () => {
   it('should handle GET requests', async () => {
-    fetch.mockResolvedValue({ status: 200, json: () => Promise.resolve({ foo: 'test' }) })
+    const responseBlob = new Blob([JSON.stringify({ foo: 'test' }, null, 2)])
+    const response = new Response(responseBlob, {
+      status: 200,
+      headers: { 'Content-Type': contentTypes.applicationJson },
+    })
+    fetch.mockResolvedValue(response)
     const result = await get<Types.UserData>('/foo')
     expect(result).toEqual(expect.objectContaining({ foo: 'test' }))
   })
 
   it('should handle GET request params', async () => {
-    fetch.mockResolvedValue({ status: 200, json: () => Promise.resolve({ foo: 'test' }) })
+    const responseBlob = new Blob([JSON.stringify({ foo: 'test' }, null, 2)])
+    const response = new Response(responseBlob, {
+      status: 200,
+      headers: { 'Content-Type': contentTypes.applicationJson },
+    })
+    fetch.mockResolvedValue(response)
     const result = await get('/foo', { p1: 'test', p2: 't&=$?est', ary: ['123', 'asdfasdf,d,asfd', '%%%'] })
     expect(result).toEqual(expect.objectContaining({ foo: 'test' }))
     // query params should be properly escaped
@@ -43,7 +53,12 @@ context('api', () => {
   })
 
   it('should handle POST correctly if contentType not specified', async () => {
-    fetch.mockResolvedValue({ status: 200, json: () => Promise.resolve({ res: 'response' }) })
+    const responseBlob = new Blob([JSON.stringify({ res: 'response' }, null, 2)])
+    const response = new Response(responseBlob, {
+      status: 200,
+      headers: { 'Content-Type': contentTypes.applicationJson },
+    })
+    fetch.mockResolvedValue(response)
     const result = await post('/foo', { p1: 'test', p2: 't&=$?est', ary: ['123', 'asdfasdf,d,asfd', '%%%'] })
 
     // Default content type should be application/json
@@ -59,7 +74,12 @@ context('api', () => {
   })
 
   it('should handle POST correctly if contentType is specified to be multipart/form-data', async () => {
-    fetch.mockResolvedValue({ status: 200, json: () => Promise.resolve({ res: 'response' }) })
+    const responseBlob = new Blob([JSON.stringify({ res: 'response' }, null, 2)])
+    const response = new Response(responseBlob, {
+      status: 200,
+      headers: { 'Content-Type': contentTypes.applicationJson },
+    })
+    fetch.mockResolvedValue(response)
     const formData = new FormData()
 
     const result = await post('/foo', { formData }, contentTypes.multipart)

--- a/VAMobile/src/store/api/api.test.ts
+++ b/VAMobile/src/store/api/api.test.ts
@@ -82,6 +82,13 @@ context('api', () => {
     fetch.mockResolvedValue(response)
     const formData = new FormData()
 
+    it("returns undefined when the Content-Type of a successful response is not 'application/json'", async () => {
+      const responseBlob = new Blob(['Success'])
+      const response = new Response(responseBlob, { status: 200, headers: { 'Content-Type': 'text/html' } })
+      fetch.mockResolvedValue(response)
+      const result = await get<Types.UserData>('/foo')
+      expect(result).toEqual(undefined)
+    })
     const result = await post('/foo', { formData }, contentTypes.multipart)
 
     const headers = expect.objectContaining({ 'Content-Type': contentTypes.multipart })

--- a/VAMobile/src/store/api/api.ts
+++ b/VAMobile/src/store/api/api.ts
@@ -187,6 +187,11 @@ const call = async function <T>(
       throw { status: response.status, endpoint, text, json }
     }
 
+    // Guard against responses that can't be parsed as JSON
+    if (!response.headers.get('Content-Type')?.startsWith('application/json')) {
+      return
+    }
+
     // No errors found, return the response
     return await response.json()
   } else {


### PR DESCRIPTION
## Description of Change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, 
need to know about this PR in order to understand why this PR was created? This could include dependencies 
introduced, changes in behavior, pointers to more detailed documentation. The description should be more 
than a link to an issue.  -->
There has been an increase in `vama_error` events, specifically containing the `JSON Parse error`. This is caused by the `/v0/user/logged-in` endpoint returning a `Content-Type` of `text/html`, which throws an error when `response.json` attempts to parse it as JSON.

To resolve this, I updated our fetch client function to return early if the response type is anything other than `application/json`, this way, non JSON responses won't be parsed. Ideally, the API shouldn't be returning a non JSON response, but this serves as a guard for whenever it does. 

## Screenshots/Video
<!-- Add screenshots or video as needed. Before/after if changes are to be compared by reviewers.
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Toggle: <details><summary></summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>
-->
N/A

## Testing
<!-- What testing was done to verify the changes (local/unit)? What testing remains? Note edge cases, or special
situations that could not be tested during development. -->
Tested by signing in to staging in the simulator. This probably can't be tested on a test build since the error wasn't crashing the app, and needs to be seen in the logs.

- [x] Tested on iOS <!-- simulator is fine -->
- [ ] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
<!-- What should reviewers look for? Copy/paste Acceptance Criteria from ticket -->
`vama_error` isn't logged for the `/v0/user/logged-in` endpoint when the response is successful.

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [ ] PR is connected to issue(s)
- [ ] Tests are included to cover this change (when possible)
- [ ] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [ ] No secrets or API keys are checked in
- [ ] All imports are absolute (no relative imports)
- [ ] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
