### PR TITLE
bug/9289-MessagesInAppReview

### DIFF
--- a/VAMobile/ios/Podfile.lock
+++ b/VAMobile/ios/Podfile.lock
@@ -1052,7 +1052,7 @@ PODS:
     - React-Core
   - react-native-notifications (5.1.0):
     - React-Core
-  - react-native-safe-area-context (4.10.4):
+  - react-native-safe-area-context (4.10.8):
     - React-Core
   - react-native-webview (13.10.4):
     - glog
@@ -1265,7 +1265,7 @@ PODS:
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
-  - RNKeychain (8.1.2):
+  - RNKeychain (8.2.0):
     - React-Core
   - RNLocalize (3.1.0):
     - React-Core
@@ -1276,7 +1276,7 @@ PODS:
     - RCT-Folly (= 2022.05.16.00)
     - React-Core
     - React-RCTImage
-  - RNSVG (14.1.0):
+  - RNSVG (14.2.0):
     - React-Core
   - SDWebImage/Core (5.19.1)
   - SDWebImageWebPCoder (0.14.5):
@@ -1600,7 +1600,7 @@ SPEC CHECKSUMS:
   react-native-document-picker: cd4d6b36a5207ad7a9e599ebb9eb0c2e84fa0b87
   react-native-image-picker: b3ba58c691bc503b33480cef8ab987f78e310c15
   react-native-notifications: 4601a5a8db4ced6ae7cfc43b44d35fe437ac50c4
-  react-native-safe-area-context: 399a5859f6acbdf67f671c69b53113f535f3b5b0
+  react-native-safe-area-context: b7daa1a8df36095a032dff095a1ea8963cb48371
   react-native-webview: dbc8171113daa2abb2499da5f327a8d0cdfcd61c
   React-nativeconfig: 2e44d0d2dd222b12a5183f4bcaa4a91881497acb
   React-NativeModulesApple: 8aa032fe6c92c1a3c63e4809d42816284a56a9b0
@@ -1633,11 +1633,11 @@ SPEC CHECKSUMS:
   RNFBRemoteConfig: bfb9f6a04a0269038a352d8386e5c77f4ff98125
   RNFileViewer: ce7ca3ac370e18554d35d6355cffd7c30437c592
   RNGestureHandler: 67d3f1f69d4d0c98d6e83f4229e3bbf997d1dc72
-  RNKeychain: a65256b6ca6ba6976132cc4124b238a5b13b3d9c
+  RNKeychain: bfe3d12bf4620fe488771c414530bf16e88f3678
   RNLocalize: e8694475db034bf601e17bd3dfa8986565e769eb
   RNReactNativeHapticFeedback: ec56a5f81c3941206fd85625fa669ffc7b4545f9
   RNScreens: e842cdccb23c0a084bd6307f6fa83fd1c1738029
-  RNSVG: ba3e7232f45e34b7b47e74472386cf4e1a676d0a
+  RNSVG: 963a95f1f5d512a13d11ffd50d351c87fb5c6890
   SDWebImage: 40b0b4053e36c660a764958bff99eed16610acbb
   SDWebImageWebPCoder: c94f09adbca681822edad9e532ac752db713eabf
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17

--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/ViewMessage/ViewMessageScreen.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/ViewMessage/ViewMessageScreen.tsx
@@ -44,6 +44,7 @@ import { GenerateFolderMessage } from 'translations/en/functions'
 import { logAnalyticsEvent, setAnalyticsUserProperty } from 'utils/analytics'
 import { showSnackBar } from 'utils/common'
 import { useAppDispatch, useDowntimeByScreenID, useTheme } from 'utils/hooks'
+import { registerReviewEvent } from 'utils/inAppReviews'
 import { getfolderName } from 'utils/secureMessaging'
 import { screenContentAllowed } from 'utils/waygateConfig'
 
@@ -150,6 +151,7 @@ function ViewMessageScreen({ route, navigation }: ViewMessageScreenProps) {
   useEffect(() => {
     if (threadFetched) {
       setAnalyticsUserProperty(UserAnalytics.vama_uses_sm())
+      registerReviewEvent()
     }
   }, [threadFetched])
 


### PR DESCRIPTION
## Description of Change
added register review events back to view message screen

## Screenshots/Video

https://github.com/user-attachments/assets/94f3ae66-3108-4eb1-b5d5-d1a5884b82db



## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
Should match the "view details increments the counter" behavior elsewhere in the app (appointments, claims, medications, etc), and trigger the counter on message details.

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
