### PR TITLE
bug/9325-ClaimsLoadingOnReviewFileRequests

### DIFF
--- a/VAMobile/src/screens/BenefitsScreen/BenefitsStackScreens.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/BenefitsStackScreens.tsx
@@ -3,7 +3,7 @@ import { ImagePickerResponse } from 'react-native-image-picker/src/types'
 
 import { createStackNavigator } from '@react-navigation/stack'
 
-import { ClaimEventData, LetterTypes } from 'api/types'
+import { ClaimData, ClaimEventData, LetterTypes } from 'api/types'
 import { ClaimType } from 'constants/claims'
 import { FULLSCREEN_SUBTASK_OPTIONS, LARGE_PANEL_OPTIONS } from 'constants/screens'
 import AskForClaimDecision from 'screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/AskForClaimDecision/AskForClaimDecision'
@@ -57,6 +57,7 @@ export type BenefitsStackParamList = {
   }
   FileRequest: {
     claimID: string
+    claim: ClaimData | undefined
   }
   FileRequestDetails: {
     claimID: string

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimDetailsScreen.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimDetailsScreen.tsx
@@ -156,7 +156,7 @@ function ClaimDetailsScreen({ navigation, route }: ClaimDetailsScreenProps) {
 
   const fileRequestsPress = () => {
     logAnalyticsEvent(Events.vama_claim_review(claimID, attributes.claimType, count))
-    navigateTo('FileRequest', { claimID })
+    navigateTo('FileRequest', { claimID, claim })
   }
 
   const getActiveClosedClaimInformationAlertOrSubmitButton = () => {

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/FileRequest.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/FileRequest.tsx
@@ -33,12 +33,21 @@ function FileRequest({ navigation, route }: FileRequestProps) {
   const theme = useTheme()
   const { t } = useTranslation(NAMESPACE.COMMON)
   const navigateTo = useRouteNavigation()
-  const { claimID } = route.params
-  const { data: claim, error: claimError, refetch: refetchClaim, isFetching: loadingClaim } = useClaim(claimID)
-  const requests = currentRequestsForVet(claim?.attributes.eventsTimeline || [])
+  const { claimID, claim } = route.params
+  const {
+    data: claimFallBack,
+    error: claimError,
+    refetch: refetchClaim,
+    isFetching: loadingClaim,
+  } = useClaim(claimID, undefined, { enabled: !claim })
+  const requests = currentRequestsForVet(
+    claim?.attributes.eventsTimeline || claimFallBack?.attributes.eventsTimeline || [],
+  )
   const { condensedMarginBetween, contentMarginBottom, standardMarginBetween, gutter } = theme.dimensions
 
-  const count = numberOfItemsNeedingAttentionFromVet(claim?.attributes.eventsTimeline || [])
+  const count = numberOfItemsNeedingAttentionFromVet(
+    claim?.attributes.eventsTimeline || claimFallBack?.attributes.eventsTimeline || [],
+  )
 
   const getRequests = (): Array<SimpleListItemObj> => {
     let requestNumber = 1
@@ -86,6 +95,15 @@ function FileRequest({ navigation, route }: FileRequestProps) {
   const viewEvaluationDetailsPress = () => {
     if (claim) {
       logAnalyticsEvent(Events.vama_claim_eval(claim.id, claim.attributes.claimType, claim.attributes.phase, count))
+    } else if (claimFallBack) {
+      logAnalyticsEvent(
+        Events.vama_claim_eval(
+          claimFallBack.id,
+          claimFallBack.attributes.claimType,
+          claimFallBack.attributes.phase,
+          count,
+        ),
+      )
     }
     navigateTo('AskForClaimDecision', { claimID })
   }

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/SelectFile/UploadFile/UploadFile.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/SelectFile/UploadFile/UploadFile.tsx
@@ -78,7 +78,7 @@ function UploadFile({ navigation, route }: UploadFileProps) {
 
   useEffect(() => {
     if (filesUploadedSuccess) {
-      navigateTo('FileRequest', { claimID: claim?.id || '' })
+      navigateTo('FileRequest', { claimID: claim?.id || '', claim })
     }
   }, [filesUploadedSuccess, claim, navigateTo])
 

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/TakePhotos/UploadOrAddPhotos/UploadOrAddPhotos.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimFileUpload/TakePhotos/UploadOrAddPhotos/UploadOrAddPhotos.tsx
@@ -103,7 +103,7 @@ function UploadOrAddPhotos({ navigation, route }: UploadOrAddPhotosProps) {
 
   useEffect(() => {
     if (filesUploadedSuccess) {
-      navigateTo('FileRequest', { claimID: claim?.id || '' })
+      navigateTo('FileRequest', { claimID: claim?.id || '', claim })
     }
   }, [filesUploadedSuccess, claim, navigateTo])
 

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimTimeline/DEPRECATED_ClaimPhase.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClaimTimeline/DEPRECATED_ClaimPhase.tsx
@@ -127,7 +127,7 @@ function DEPRECATED_ClaimPhase({ phase, current, attributes, claimID }: ClaimPha
 
   const fileRequestsPress = () => {
     logAnalyticsEvent(Events.vama_claim_review(claimID, attributes.claimType, count))
-    navigateTo('FileRequest', { claimID })
+    navigateTo('FileRequest', { claimID, undefined })
   }
 
   return (


### PR DESCRIPTION
## Description of Change
passed the already loaded claim to the file request screen, no need to reload due to the refresh timer right after a user is already on the details screen. Does fall back on api if we need to load for whatever reason of the claim data being undefined.

## Screenshots/Video

https://github.com/user-attachments/assets/46b280e7-5d82-4a9d-b4a4-604d4dc053a5



## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
no longer displays unnecessary loading screens

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
