### PR TITLE
9428-Dylan-NoAppointmentsSpacing

### DIFF
--- a/VAMobile/src/screens/HealthScreen/Appointments/NoAppointments/NoAppointments.tsx
+++ b/VAMobile/src/screens/HealthScreen/Appointments/NoAppointments/NoAppointments.tsx
@@ -26,7 +26,8 @@ export function NoAppointments({ subText, subTextA11yLabel, showVAGovLink = true
       justifyContent="center"
       mx={theme.dimensions.gutter}
       {...testIdProps('Appointments: No-appointments-page')}
-      alignItems="center">
+      alignItems="center"
+      mt={theme.dimensions.textAndButtonLargeMargin}>
       <Box {...testIdProps(t('noAppointments.youDontHave'))} accessibilityRole="header" accessible={true}>
         <TextView variant="MobileBodyBold" textAlign="center">
           {t('noAppointments.youDontHave')}


### PR DESCRIPTION
## Description of Change
Added some spacing between the segmented controller and the no appointments text.

## Screenshots/Video
Toggle: <details><summary>Before/after: </summary><img src="https://github.com/user-attachments/assets/b9144a18-dbb5-4a0b-93a3-02e7b9bd4903" width="49%" />&nbsp;&nbsp;<img src="https://github.com/user-attachments/assets/420c2e78-32c7-43e5-a738-603207dc217c" width="49%" /></details>


## Testing
yarn testing

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
Add spacing to the top of the no appointments screen so it is more in the center of the screen

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
