### PR TITLE
bug/9653-MessageAttachmentLoadingIndicatorFix

### DIFF
--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/ViewMessage/MessageCard.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/ViewMessage/MessageCard.tsx
@@ -34,7 +34,7 @@ function MessageCard({ message }: MessageCardProps) {
   const dateTime = getFormattedDateAndTimeZone(sentDate)
   const navigateTo = useRouteNavigation()
   const fileToGet = {} as SecureMessagingAttachment
-  const { isPending: attachmentFetchPending, refetch: refetchFile } = useDownloadFileAttachment(fileToGet, {
+  const { isFetching: attachmentFetchPending, refetch: refetchFile } = useDownloadFileAttachment(fileToGet, {
     enabled: false,
   })
   const { demoMode } = useSelector<RootState, DemoState>((state) => state.demo)
@@ -79,7 +79,7 @@ function MessageCard({ message }: MessageCardProps) {
   }
 
   function getAttachment() {
-    if (attachmentFetchPending && !attachments?.length) {
+    if (attachmentFetchPending) {
       const loadingScrollViewStyle: ViewStyle = {
         backgroundColor: theme.colors.background.contentBox,
       }


### PR DESCRIPTION
## Description of Change
Fixed loading indicator not appearing when clicking on a attachment in SM

## Screenshots/Video


https://github.com/user-attachments/assets/99532526-addf-472f-86a6-9c4754ad835f


## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
Loading indicator should appear when tapping on a attachment

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
