### PR TITLE
feature/9683-NotEnrolledSMAnalytic

### DIFF
--- a/VAMobile/src/constants/analytics.ts
+++ b/VAMobile/src/constants/analytics.ts
@@ -1080,6 +1080,11 @@ export const Events = {
       name: 'vama_sm_nonurgent',
     }
   },
+  vama_sm_notenrolled: (): Event => {
+    return {
+      name: 'vama_sm_notenrolled',
+    }
+  },
   vama_sm_open: (sm_id: number, location: string, status: string): Event => {
     return {
       name: 'vama_sm_open',

--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/NotEnrolledSM/NotEnrolledSM.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/NotEnrolledSM/NotEnrolledSM.tsx
@@ -1,17 +1,22 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { LinkProps } from '@department-of-veterans-affairs/mobile-component-library/src/components/Link/Link'
 
 import { Box, LinkWithAnalytics, TextArea, TextView, VABulletList, VAScrollView } from 'components'
+import { Events } from 'constants/analytics'
 import { NAMESPACE } from 'constants/namespaces'
 import { a11yLabelVA } from 'utils/a11yLabel'
+import { logAnalyticsEvent } from 'utils/analytics'
 import getEnv from 'utils/env'
 import { useTheme } from 'utils/hooks'
 
 const { LINK_URL_UPGRADE_MY_HEALTHEVET_PREMIUM_ACCOUNT } = getEnv()
 
 function NotEnrolledSM() {
+  useEffect(() => {
+    logAnalyticsEvent(Events.vama_sm_notenrolled())
+  }, [])
   const { t } = useTranslation(NAMESPACE.COMMON)
   const theme = useTheme()
   const { contentMarginBottom, standardMarginBetween } = theme.dimensions


### PR DESCRIPTION
## Description of Change
Analytic added for when not enrolled SM appears

## Screenshots/Video
![Screenshot 2024-09-24 at 12 10 45 PM](https://github.com/user-attachments/assets/134ef62b-7184-4c1c-9c16-25f78afed187)
<img width="481" alt="Screenshot 2024-09-24 at 12 10 50 PM" src="https://github.com/user-attachments/assets/7f7ccfd8-befe-412a-8333-68242424275d">


## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
Analytic should fire when not enrolled SM appears

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
