### PR TITLE
cu: Update fornts webviewTitle and textWithIconButton to min 16

### DIFF
--- a/VAMobile/src/screens/WebviewScreen/WebviewTitle.tsx
+++ b/VAMobile/src/screens/WebviewScreen/WebviewTitle.tsx
@@ -26,7 +26,7 @@ function WebviewTitle({ title }: WebviewTitleProps) {
       <Box mr={theme.dimensions.textIconMargin}>
         <Icon name={'Lock'} height={36} width={24} fill={theme.colors.text.webviewTitle} preventScaling={true} />
       </Box>
-      <TextView color="webviewTitle" allowFontScaling={false}>
+      <TextView variant="webviewTitle" color="webviewTitle" allowFontScaling={false}>
         {title}
       </TextView>
     </Box>

--- a/VAMobile/src/styles/themes/standardTheme.ts
+++ b/VAMobile/src/styles/themes/standardTheme.ts
@@ -135,8 +135,8 @@ const fontSizes = {
     lineHeight: 21,
   },
   textWithIconButton: {
-    fontSize: 12,
-    lineHeight: 15,
+    fontSize: 16,
+    lineHeight: 20,
   },
   UnreadMessagesTag: {
     fontSize: 20,
@@ -152,8 +152,8 @@ const fontSizes = {
     lineHeight: 30,
   },
   webviewTitle: {
-    fontSize: 12,
-    lineHeight: 12,
+    fontSize: 20,
+    lineHeight: 30,
   },
   veteranStatus: {
     fontSize: 16,


### PR DESCRIPTION
## Description of Change
Update `webviewTitle` and `textWithIconButton` font sizes to be a minimum of 16. 
`webviewTitle` variant was unused and very small so it was updated to match the default `MobileBody` sizing
Update `<WebViewTitle />` component to use `variant="webviewTitle"` explicitly and keep the original sizing.

<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, 
need to know about this PR in order to understand why this PR was created? This could include dependencies 
introduced, changes in behavior, pointers to more detailed documentation. The description should be more 
than a link to an issue.  -->

## Screenshots/Video

<details>
<summary>iOS</summary>

| Before webviewTitle | After webviewTitle |
| ---- | ---- |
| <img width="100%" alt="iphone_standard_before_webviewTitle" src="https://github.com/user-attachments/assets/f6510399-a2f3-4d91-8aa1-9878a94f927f"> | <img width="100%" alt="iphone_standard_after_webviewTitle" src="https://github.com/user-attachments/assets/ac4b83bb-d5d4-4016-8b13-84cdaffe9ec5"> |
| <img width="534" alt="Screenshot 2024-09-26 at 1 24 33 PM" src="https://github.com/user-attachments/assets/03ac31a8-ea8a-4871-a4c0-8a12d54bfd9a"> | <img width="534" alt="iphone_mini_after_webTitle" src="https://github.com/user-attachments/assets/1eb52d78-2a1d-4bae-9826-17c3b68fefdb"> |

| Before textWithIconButton | After textWithIconButton |
| ---- | ---- |
| <img width="458" alt="iphone_standard_before_textWithIconButton" src="https://github.com/user-attachments/assets/129a062d-5271-45d4-aeea-97dcfcc710be"> | <img width="458" alt="iphone_standard_after_textWithIconButton" src="https://github.com/user-attachments/assets/27683dcd-45c1-4c43-8b83-3a470cf55608"> |
| <img width="534" alt="Screenshot 2024-09-26 at 1 23 42 PM" src="https://github.com/user-attachments/assets/0160bd60-3a9b-4e4e-9cbf-e771e8e91891"> | <img width="534" alt="iphone_mini_after_textWithiconButton" src="https://github.com/user-attachments/assets/eb7aff9e-4719-4eea-aab6-f729dc5c66d7"> |
| <img width="582" alt="Screenshot 2024-10-15 at 1 50 05 PM" src="https://github.com/user-attachments/assets/e144de87-6b2a-4a44-8881-86a3df2457d7"> | <img width="582" alt="Screenshot 2024-10-15 at 1 38 10 PM" src="https://github.com/user-attachments/assets/b693e156-5978-4082-9d06-e476f79d4bc6"> |

</details>

<details>
<summary>Android</summary>

| Before webviewTitle | After webviewTitle |
| ---- | ---- |
|<img width="519" alt="Screenshot 2024-09-26 at 12 33 57 PM" src="https://github.com/user-attachments/assets/56238d85-68e7-4fd1-9d0a-8e23bcdbe235">|<img width="519" alt="Screenshot 2024-09-26 at 12 11 23 PM" src="https://github.com/user-attachments/assets/f8681c8b-064d-4b99-815b-6128d744f974">|
| <img width="441" alt="Screenshot 2024-09-26 at 12 33 37 PM" src="https://github.com/user-attachments/assets/130be0c5-95f0-4b48-8d07-3a257c190235"> | <img width="441" alt="Screenshot 2024-09-26 at 12 18 45 PM" src="https://github.com/user-attachments/assets/ae545cbc-bc22-4cad-8455-5d08f064eae8"> |

| Before textWithIconButton | After textWithIconButton |
| ---- | ---- |
|<img width="441" alt="Screenshot 2024-09-26 at 12 30 41 PM" src="https://github.com/user-attachments/assets/5040976a-8768-425e-bbd9-ac70717bdf58">|<img width="441" alt="Screenshot 2024-09-26 at 12 19 40 PM" src="https://github.com/user-attachments/assets/7851c40d-5d90-4bbc-82d0-62d42e9639f1">|
|<img width="519" alt="Screenshot 2024-09-26 at 12 30 22 PM" src="https://github.com/user-attachments/assets/44cdd490-34a4-41d5-af7a-b36484a6d707">|<img width="519" alt="Screenshot 2024-09-26 at 12 12 29 PM" src="https://github.com/user-attachments/assets/c592ca9d-b089-4af6-a5c1-e8a1dff8df26">| 
|<img width="519" alt="Screenshot 2024-10-15 at 1 49 25 PM" src="https://github.com/user-attachments/assets/7cc9551e-9e72-4690-b6bd-6fcd995dcbab">|<img width="519" alt="Screenshot 2024-10-15 at 1 41 12 PM" src="https://github.com/user-attachments/assets/3647561d-686b-4fb2-8408-70c0251a61ed">|

</details


## Testing

**Test Plan A**
1. Launch App and tap on "Find a VA Location"
2. Observe the Web view title "va.gov" has not changed in style

**Test Plan B**
1. Sign in with `vets.gov.user+361` 
2. Observe the bottom tab bar icon text is now larger and a minimum of 16.

<!-- What testing was done to verify the changes (local/unit)? What testing remains? Note edge cases, or special
situations that could not be tested during development. -->

- [X] Tested on iOS 
- [X] Tested on Android 

## Reviewer Validations
Tab View icon label is now a minimum of 16
WebView title is now a minimum of 16
<!-- What should reviewers look for? Copy/paste Acceptance Criteria from ticket -->

## PR Checklist

<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [X] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [X] No secrets or API keys are checked in
~~- [ ] All imports are absolute (no relative imports)~~
~~- [ ] New functions and Redux work have proper TSDoc annotations~~

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
