### PR TITLE
cu: 5779 Audit VABulletList for a11yLabel usage

### DIFF
--- a/VAMobile/src/components/VABulletList.tsx
+++ b/VAMobile/src/components/VABulletList.tsx
@@ -94,7 +94,7 @@ const VABulletList: FC<VABulletListProps> = ({ listOfText, paragraphSpacing }) =
             <Box mr={20} mt={12}>
               <VAIcon name="Bullet" fill={color || 'bodyText'} height={6} width={6} />
             </Box>
-            <TextView {...textViewProps} accessibilityLabel={a11yLabel || text}>
+            <TextView {...textViewProps} accessibilityLabel={a11yLabel}>
               {!!boldedTextPrefix && <TextView variant="MobileBodyBold">{boldedTextPrefix}</TextView>}
               {text.trim()}
               {!!boldedText && <TextView variant="MobileBodyBold">{boldedText}</TextView>}

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/AppealDetailsScreen/AppealStatus/AppealCurrentStatus/AppealCurrentStatus.test.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/AppealDetailsScreen/AppealStatus/AppealCurrentStatus/AppealCurrentStatus.test.tsx
@@ -181,9 +181,8 @@ context('AppealStatus', () => {
         ),
       ).toBeTruthy()
       expect(
-        screen.getByLabelText("Submit VA Form 9 to continue your appeal to the Board of Veterans' Appeals,"),
+        screen.getByText("Submit VA Form 9 to continue your appeal to the Board of Veterans' Appeals, or"),
       ).toBeTruthy()
-      expect(screen.getByText('or')).toBeTruthy()
       expect(screen.getByText('Opt in to the new decision review process')).toBeTruthy()
     })
   })

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClosedClaimInfo/ClosedClaimStatusDetails.test.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/ClaimDetailsScreen/ClaimStatus/ClosedClaimInfo/ClosedClaimStatusDetails.test.tsx
@@ -39,8 +39,8 @@ context('ClosedClaimStatusDetails', () => {
 
   it('renders list of claimed items', () => {
     renderWithProps()
-    expect(screen.getByLabelText('Hearing Loss (Increase)')).toBeTruthy()
-    expect(screen.getByLabelText('Ankle strain (related to: PTSD - Combat POW) (New)')).toBeTruthy()
-    expect(screen.getByLabelText('Diabetes mellitus2 (Secondary)')).toBeTruthy()
+    expect(screen.getByText('Hearing Loss (Increase)')).toBeTruthy()
+    expect(screen.getByText('Ankle strain (related to: PTSD - Combat POW) (New)')).toBeTruthy()
+    expect(screen.getByText('Diabetes mellitus2 (Secondary)')).toBeTruthy()
   })
 })

--- a/VAMobile/src/screens/HealthScreen/Pharmacy/PrescriptionDetails/PrescriptionsDetailsBanner.tsx
+++ b/VAMobile/src/screens/HealthScreen/Pharmacy/PrescriptionDetails/PrescriptionsDetailsBanner.tsx
@@ -34,7 +34,6 @@ function PrescriptionsDetailsBanner() {
       {
         text: t('prescription.details.banner.bullet3'),
         boldedText: ' ' + t('or'),
-        a11yLabel: t('prescription.details.banner.bullet3') + ' ' + t('or'),
       },
       { text: t('prescription.details.banner.bullet4') },
     ]

--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/ReplyHelp/ReplyHelp.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/ReplyHelp/ReplyHelp.tsx
@@ -42,7 +42,6 @@ function ReplyHelp() {
             {
               boldedTextPrefix: t('secureMessaging.replyHelp.ifYoureInCrisis'),
               text: t('secureMessaging.replyHelp.connectWithOur'),
-              a11yLabel: t('secureMessaging.replyHelp.ifYoureInCrisis') + t('secureMessaging.replyHelp.connectWithOur'),
             },
           ]}
           paragraphSpacing={true}
@@ -56,7 +55,6 @@ function ReplyHelp() {
               {
                 boldedTextPrefix: t('secureMessaging.replyHelp.ifYouThink'),
                 text: t('secureMessaging.replyHelp.call911OrGoTo'),
-                a11yLabel: t('secureMessaging.replyHelp.ifYouThink') + t('secureMessaging.replyHelp.call911OrGoTo'),
               },
             ]}
             paragraphSpacing={true}

--- a/VAMobile/src/screens/HomeScreen/ProfileScreen/PersonalInformationScreen/GenderIdentityScreen/WhatToKnowScreen/WhatToKnowScreen.tsx
+++ b/VAMobile/src/screens/HomeScreen/ProfileScreen/PersonalInformationScreen/GenderIdentityScreen/WhatToKnowScreen/WhatToKnowScreen.tsx
@@ -33,33 +33,21 @@ function WhatToKnowScreen({}: WhatToKnowScreenProps) {
                 variant: 'MobileBody',
                 boldedTextPrefix: t('personalInformation.genderIdentity.whatToKnow.ReasonsToShare.1'),
                 text: t('personalInformation.genderIdentity.whatToKnow.ReasonsToShare.2'),
-                a11yLabel:
-                  t('personalInformation.genderIdentity.whatToKnow.ReasonsToShare.1') +
-                  t('personalInformation.genderIdentity.whatToKnow.ReasonsToShare.2'),
               },
               {
                 variant: 'MobileBody',
                 boldedTextPrefix: t('personalInformation.genderIdentity.whatToKnow.whoCanAccess'),
                 text: t('personalInformation.genderIdentity.whatToKnow.privacy'),
-                a11yLabel:
-                  t('personalInformation.genderIdentity.whatToKnow.whoCanAccess') +
-                  t('personalInformation.genderIdentity.whatToKnow.privacy'),
               },
               {
                 variant: 'MobileBody',
                 boldedTextPrefix: t('personalInformation.genderIdentity.whatToKnow.healthRecordsOnly.1'),
                 text: t('personalInformation.genderIdentity.whatToKnow.healthRecordsOnly.2'),
-                a11yLabel:
-                  t('personalInformation.genderIdentity.whatToKnow.healthRecordsOnly.1') +
-                  t('personalInformation.genderIdentity.whatToKnow.healthRecordsOnly.2'),
               },
               {
                 variant: 'MobileBody',
                 boldedTextPrefix: t('personalInformation.genderIdentity.whatToKnow.birthCertificate.1'),
                 text: t('personalInformation.genderIdentity.whatToKnow.birthCertificate.2'),
-                a11yLabel:
-                  t('personalInformation.genderIdentity.whatToKnow.birthCertificate.1') +
-                  t('personalInformation.genderIdentity.whatToKnow.birthCertificate.2'),
               },
             ]}
           />

--- a/VAMobile/src/screens/auth/LoaGate/LoaGate.tsx
+++ b/VAMobile/src/screens/auth/LoaGate/LoaGate.tsx
@@ -21,7 +21,6 @@ function LoaGate({}: LoaGateProps) {
   const bulletOne = {
     text: t('loaGate.readMore.bulletOne'),
     boldedText: ' ' + t('loaGate.readMore.or'),
-    a11yLabel: t('loaGate.readMore.bulletOne.a11y'),
   }
 
   const bodyTextProps: TextViewProps = {


### PR DESCRIPTION
## Description of Change
- Modify VABulletList so that the `accessibilityLabel` is only set when `a11yLabel` is specified otherwise it is automatically created from traversing the children elements. (although not the case in tests)
- Audit usages of VABulletList and remove unneeded and redundant `a11yLabel` 
- Keep usages of `a11yLabel` when `a11yLabelVA()` is used to maintain accesibility
- Update tests to account for the `accessibilityLabel` not being generated and changing some usages of `getByLabelText` to `getByText`

<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, 
need to know about this PR in order to understand why this PR was created? This could include dependencies 
introduced, changes in behavior, pointers to more detailed documentation. The description should be more 
than a link to an issue.  -->


## Screenshots/Video
| Before | After |
| --- | --- |
| <img width="980" alt="Screenshot 2024-09-27 at 12 53 30 PM" src="https://github.com/user-attachments/assets/0b0269ae-b493-4811-ae52-63ff70058aca">|<img width="1046" alt="Screenshot 2024-09-27 at 12 49 12 PM" src="https://github.com/user-attachments/assets/b6aab7d3-2b60-4b27-b5b9-ec44ac00e63f">|


https://github.com/user-attachments/assets/851437b8-fa6d-49d2-af3d-2720f5c38605




<!-- Add screenshots or video as needed. Before/after if changes are to be compared by reviewers.
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Toggle: <details><summary></summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>
-->

## Testing
<!-- What testing was done to verify the changes (local/unit)? What testing remains? Note edge cases, or special
situations that could not be tested during development. -->

Tested a single instance of the change `LoaGate`. All affected pages need to be checked.

Remaining
- [ ] Prescription Details Banner
- [ ] SecureMesasging ReplyHelp
- [ ] WhatToKnowScreen
- [x] LoaGate

Dev Test Plan
1. On a fresh install of the app tap "Sign In"
2. On the pre-sign in screen tap and expand the "Read more if you haven't yet verified"
3. Scroll to the bottom list of text 
4. Use the accessibility inspector / Tapback to announce the first bullet point "Use a picture of your driver's license or passport, or" 
5. Expect the bolded text "or" at the end of the announced.

- [x] Tested on iOS <!-- simulator is fine -->
- [X] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
<!-- What should reviewers look for? Copy/paste Acceptance Criteria from ticket -->

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
