### PR TITLE
CU/9840-rachael-detox-militaryInfo-veteranStatusCard-replace-by-text

### DIFF
--- a/VAMobile/e2e/tests/MilitaryInformation.e2e.ts
+++ b/VAMobile/e2e/tests/MilitaryInformation.e2e.ts
@@ -1,11 +1,19 @@
 import { by, device, element, expect } from 'detox'
 import { setTimeout } from 'timers/promises'
 
-import { changeMockData, checkImages, loginToDemoMode, openMilitaryInformation, openProfile } from './utils'
+import {
+  CommonE2eIdConstants,
+  changeMockData,
+  checkImages,
+  loginToDemoMode,
+  openMilitaryInformation,
+  openProfile,
+} from './utils'
 
 export const MilitaryInformationE2eIdConstants = {
   MILITARY_DATE_TEXT: 'July 13, 1970 – August 31, 1998',
-  SERVICE_INFORMATION_INCORRECT_TITLE_TEXT: "What if my military service information doesn't look right?",
+  SERVICE_INFORMATION_INCORRECT_ID: 'militaryServiceIncorrectLinkID',
+  SERVICE_INFORMATION_INCORRECT_SWIPE: 'IncorrectServiceTestID',
   SERVICE_INFORMATION_INCORRECT_BODY_LABEL_1:
     'Some Veterans have reported seeing military service information in their V-A .gov profiles that doesn’t seem right. When this happens, it’s because there’s an error in the information we’re pulling into V-A .gov from the Defense Enrollment Eligibility Reporting System (D-E-E-R-S).',
   SERVICE_INFORMATION_INCORRECT_BODY_LABEL_2:
@@ -52,10 +60,7 @@ describe('Military Info Screen', () => {
   it('should open new screen if military service information is incorrect', async () => {
     await openProfile()
     await openMilitaryInformation()
-    await element(by.text(MilitaryInformationE2eIdConstants.SERVICE_INFORMATION_INCORRECT_TITLE_TEXT)).tap()
-    await expect(
-      element(by.text(MilitaryInformationE2eIdConstants.SERVICE_INFORMATION_INCORRECT_TITLE_TEXT)).atIndex(1),
-    ).toExist()
+    await element(by.id(MilitaryInformationE2eIdConstants.SERVICE_INFORMATION_INCORRECT_ID)).tap()
     await expect(
       element(by.label(MilitaryInformationE2eIdConstants.SERVICE_INFORMATION_INCORRECT_BODY_LABEL_1)),
     ).toExist()
@@ -65,11 +70,11 @@ describe('Military Info Screen', () => {
     await expect(
       element(by.label(MilitaryInformationE2eIdConstants.SERVICE_INFORMATION_INCORRECT_BODY_LABEL_3)),
     ).toExist()
-    await expect(element(by.id('CallVATestID'))).toExist()
-    await element(by.id('IncorrectServiceTestID')).swipe('up')
+    await expect(element(by.id(CommonE2eIdConstants.CALL_VA_PHONE_NUMBER_ID))).toExist()
+    await element(by.id(MilitaryInformationE2eIdConstants.SERVICE_INFORMATION_INCORRECT_SWIPE)).swipe('up')
     if (device.getPlatform() === 'android') {
       await device.disableSynchronization()
-      await element(by.id('CallVATestID')).tap()
+      await element(by.id(CommonE2eIdConstants.CALL_VA_TTY_PHONE_NUMBER_ID)).tap()
       await setTimeout(5000)
       await device.enableSynchronization()
       await device.launchApp({ newInstance: false })

--- a/VAMobile/e2e/tests/VeteranStatusCard.e2e.ts
+++ b/VAMobile/e2e/tests/VeteranStatusCard.e2e.ts
@@ -2,6 +2,7 @@ import { by, device, element, expect, waitFor } from 'detox'
 import { setTimeout } from 'timers/promises'
 
 import {
+  CommonE2eIdConstants,
   changeMockData,
   checkImages,
   loginToDemoMode,
@@ -13,7 +14,7 @@ import {
 } from './utils'
 
 export const VeteranStatusCardConstants = {
-  VETERAN_STATUS_TEXT: 'Proof of Veteran status',
+  VETERAN_STATUS_ID: 'veteranStatusButtonID',
   VETERAN_STATUS_NAME_TEXT: 'Kimberly Washington',
   VETERAN_STATUS_MILITARY_BRANCH_TEXT: 'United States Coast Guard',
   VETERAN_STATUS_DISABILITY_RATING_TEXT: '100% service connected',
@@ -24,8 +25,9 @@ export const VeteranStatusCardConstants = {
   VETERAN_STATUS_DISCLAIMER_TEXT:
     "You can use this Veteran status to prove you served in the United States Uniformed Services. This status doesn't entitle you to any VA benefits.",
   VETERAN_STATUS_DOB_DISABILITY_ERROR_PHONE_TEXT: '800-827-1000',
-  VETERAN_STATUS_DOB_DISABILITY_ERROR_TTY_TEXT: 'TTY: 711',
   VETERAN_STATUS_PERIOD_OF_SERVICE_ERROR_PHONE_TEXT: '800-538-9552',
+  VETERAN_STATUS_CLOSE_ID: 'veteranStatusCloseID',
+  BACK_TO_PROFILE_ID: 'backToProfileID',
 }
 
 beforeAll(async () => {
@@ -45,9 +47,7 @@ export async function validateVeteranStatusDesign() {
   await expect(element(by.id('veteranStatusDOBTestID'))).toExist()
   await expect(element(by.text(VeteranStatusCardConstants.VETERAN_STATUS_DISCLAIMER_TEXT))).toExist()
   await expect(element(by.text(VeteranStatusCardConstants.VETERAN_STATUS_DOB_DISABILITY_ERROR_PHONE_TEXT))).toExist()
-  await expect(
-    element(by.text(VeteranStatusCardConstants.VETERAN_STATUS_DOB_DISABILITY_ERROR_TTY_TEXT)).atIndex(0),
-  ).toExist()
+  await expect(element(by.id(CommonE2eIdConstants.CALL_VA_TTY_PHONE_NUMBER_ID)).atIndex(0)).toExist()
   await expect(element(by.text(VeteranStatusCardConstants.VETERAN_STATUS_PERIOD_OF_SERVICE_ERROR_PHONE_TEXT))).toExist()
   const veteranStatusCardBranchIcon = await element(by.id('veteranStatusCardBranchEmblem')).takeScreenshot(
     'veteranStatusCardBranchIcon',
@@ -67,11 +67,11 @@ export async function tapPhoneAndTTYLinks() {
     await device.takeScreenshot('VeteranStatusDOBorDisabilityErrorPhoneNumber')
     await device.launchApp({ newInstance: false })
 
-    await waitFor(element(by.text(VeteranStatusCardConstants.VETERAN_STATUS_DOB_DISABILITY_ERROR_TTY_TEXT)).atIndex(0))
+    await waitFor(element(by.id(CommonE2eIdConstants.CALL_VA_TTY_PHONE_NUMBER_ID)).atIndex(0))
       .toBeVisible()
       .whileElement(by.id('veteranStatusTestID'))
       .scroll(200, 'down')
-    await element(by.text(VeteranStatusCardConstants.VETERAN_STATUS_DOB_DISABILITY_ERROR_TTY_TEXT)).atIndex(0).tap()
+    await element(by.id(CommonE2eIdConstants.CALL_VA_TTY_PHONE_NUMBER_ID)).atIndex(0).tap()
     try {
       await element(by.text('Dismiss')).tap()
       await element(by.text(VeteranStatusCardConstants.VETERAN_STATUS_PERIOD_OF_SERVICE_ERROR_PHONE_TEXT)).tap()
@@ -100,39 +100,39 @@ export async function verifyMilitaryInfo(militaryBranch) {
       militaryBranch,
     )
     await element(by.text('Home')).tap()
-    await waitFor(element(by.text(VeteranStatusCardConstants.VETERAN_STATUS_TEXT)))
+    await waitFor(element(by.id(VeteranStatusCardConstants.VETERAN_STATUS_ID)))
       .toBeVisible()
       .whileElement(by.id('homeScreenID'))
       .scroll(200, 'down')
-    await element(by.text(VeteranStatusCardConstants.VETERAN_STATUS_TEXT)).tap()
+    await element(by.id(VeteranStatusCardConstants.VETERAN_STATUS_ID)).tap()
     await expect(element(by.text(militaryBranch)).atIndex(1)).toExist()
-    await element(by.text('Close')).tap()
-    await expect(element(by.text(VeteranStatusCardConstants.VETERAN_STATUS_TEXT))).toExist()
+    await element(by.id(VeteranStatusCardConstants.VETERAN_STATUS_CLOSE_ID)).tap()
+    await expect(element(by.id(VeteranStatusCardConstants.VETERAN_STATUS_ID))).toExist()
     await expect(element(by.text(militaryBranch))).toExist()
     await openProfile()
-    await element(by.text(VeteranStatusCardConstants.VETERAN_STATUS_TEXT)).tap()
+    await element(by.id(VeteranStatusCardConstants.VETERAN_STATUS_ID)).tap()
     await expect(element(by.text(militaryBranch)).atIndex(1)).toExist()
-    await element(by.text('Close')).tap()
-    await expect(element(by.text(VeteranStatusCardConstants.VETERAN_STATUS_TEXT))).toExist()
+    await element(by.id(VeteranStatusCardConstants.VETERAN_STATUS_CLOSE_ID)).tap()
+    await expect(element(by.id(VeteranStatusCardConstants.VETERAN_STATUS_ID))).toExist()
     await expect(element(by.text(militaryBranch))).toExist()
   })
 }
 describe('Veteran Status Card', () => {
   it('should match design in the home screen', async () => {
-    await waitFor(element(by.text(VeteranStatusCardConstants.VETERAN_STATUS_TEXT)))
+    await waitFor(element(by.id(VeteranStatusCardConstants.VETERAN_STATUS_ID)))
       .toBeVisible()
       .whileElement(by.id('homeScreenID'))
       .scroll(200, 'down')
-    await element(by.text(VeteranStatusCardConstants.VETERAN_STATUS_TEXT)).tap()
+    await element(by.id(VeteranStatusCardConstants.VETERAN_STATUS_ID)).tap()
     await validateVeteranStatusDesign()
   })
 
   tapPhoneAndTTYLinks()
 
   it('should match design in the profile screen', async () => {
-    await element(by.text('Close')).tap()
+    await element(by.id(VeteranStatusCardConstants.VETERAN_STATUS_CLOSE_ID)).tap()
     await openProfile()
-    await element(by.text(VeteranStatusCardConstants.VETERAN_STATUS_TEXT)).tap()
+    await element(by.id(VeteranStatusCardConstants.VETERAN_STATUS_ID)).tap()
     await validateVeteranStatusDesign()
   })
 
@@ -143,28 +143,28 @@ describe('Veteran Status Card', () => {
     await expect(element(by.text(VeteranStatusCardConstants.VETERAN_STATUS_PERIOD_OF_SERVICE_PERIOD_1_TEXT))).toExist()
     await expect(element(by.text(VeteranStatusCardConstants.VETERAN_STATUS_MILITARY_BRANCH_TEXT)).atIndex(1)).toExist()
     await expect(element(by.text(VeteranStatusCardConstants.VETERAN_STATUS_PERIOD_OF_SERVICE_PERIOD_2_TEXT))).toExist()
-    await element(by.text('Close')).tap()
+    await element(by.id(VeteranStatusCardConstants.VETERAN_STATUS_CLOSE_ID)).tap()
     await openMilitaryInformation()
     await expect(element(by.text(VeteranStatusCardConstants.VETERAN_STATUS_PERIOD_OF_SERVICE_BRANCH_1_TEXT))).toExist()
     await expect(element(by.text(VeteranStatusCardConstants.VETERAN_STATUS_PERIOD_OF_SERVICE_PERIOD_1_TEXT))).toExist()
     await expect(element(by.text(VeteranStatusCardConstants.VETERAN_STATUS_MILITARY_BRANCH_TEXT))).toExist()
     await expect(element(by.text(VeteranStatusCardConstants.VETERAN_STATUS_PERIOD_OF_SERVICE_PERIOD_2_TEXT))).toExist()
-    await element(by.text('Profile')).tap()
+    await element(by.id(VeteranStatusCardConstants.BACK_TO_PROFILE_ID)).tap()
   })
 
   it('verify the date of birth matches the dob in the app', async () => {
-    await element(by.text(VeteranStatusCardConstants.VETERAN_STATUS_TEXT)).tap()
+    await element(by.id(VeteranStatusCardConstants.VETERAN_STATUS_ID)).tap()
     await expect(element(by.text(VeteranStatusCardConstants.VETERAN_STATUS_DATE_OF_BIRTH_TEXT))).toExist()
-    await element(by.text('Close')).tap()
+    await element(by.id(VeteranStatusCardConstants.VETERAN_STATUS_CLOSE_ID)).tap()
     await openPersonalInformation()
     await expect(element(by.text(VeteranStatusCardConstants.VETERAN_STATUS_DATE_OF_BIRTH_TEXT))).toExist()
-    await element(by.text('Profile')).tap()
+    await element(by.id(VeteranStatusCardConstants.BACK_TO_PROFILE_ID)).tap()
   })
 
   it('verify the disability rating matches the app', async () => {
-    await element(by.text(VeteranStatusCardConstants.VETERAN_STATUS_TEXT)).tap()
+    await element(by.id(VeteranStatusCardConstants.VETERAN_STATUS_ID)).tap()
     await expect(element(by.text(VeteranStatusCardConstants.VETERAN_STATUS_DISABILITY_RATING_TEXT))).toExist()
-    await element(by.text('Close')).tap()
+    await element(by.id(VeteranStatusCardConstants.VETERAN_STATUS_CLOSE_ID)).tap()
     await openBenefits()
     await openDisabilityRating()
     await expect(element(by.text('100%')).atIndex(1)).toExist()

--- a/VAMobile/src/screens/HomeScreen/ProfileScreen/MilitaryInformationScreen/MilitaryInformationScreen.tsx
+++ b/VAMobile/src/screens/HomeScreen/ProfileScreen/MilitaryInformationScreen/MilitaryInformationScreen.tsx
@@ -78,7 +78,8 @@ function MilitaryInformationScreen({ navigation }: MilitaryInformationScreenProp
     <FeatureLandingTemplate
       backLabel={t('profile.title')}
       backLabelOnPress={navigation.goBack}
-      title={t('militaryInformation.title')}>
+      title={t('militaryInformation.title')}
+      backLabelTestID="backToProfileID">
       {!mhNotInDowntime ? (
         <ErrorComponent screenID={ScreenIDTypesConstants.MILITARY_INFORMATION_SCREEN_ID} />
       ) : loadingCheck ? (
@@ -109,7 +110,7 @@ function MilitaryInformationScreen({ navigation }: MilitaryInformationScreenProp
               type="custom"
               text={t('militaryInformation.incorrectServiceInfo')}
               onPress={onIncorrectService}
-              testID={t('militaryInformation.incorrectServiceInfo')}
+              testID="militaryServiceIncorrectLinkID"
             />
           </Box>
         </>

--- a/VAMobile/src/screens/HomeScreen/VeteranStatusScreen/VeteranStatusScreen.tsx
+++ b/VAMobile/src/screens/HomeScreen/VeteranStatusScreen/VeteranStatusScreen.tsx
@@ -94,7 +94,8 @@ function VeteranStatusScreen({ navigation }: VeteranStatusScreenProps) {
       rightButtonText={t('close')}
       dividerMarginBypass={true}
       removeInsets={true}
-      testID="veteranStatusTestID">
+      testID="veteranStatusTestID"
+      rightButtonTestID="veteranStatusCloseID">
       <Box
         mx={isPortrait ? theme.dimensions.gutter : theme.dimensions.headerHeight}
         alignItems="center"


### PR DESCRIPTION
## Description of Change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, 
need to know about this PR in order to understand why this PR was created? This could include dependencies 
introduced, changes in behavior, pointers to more detailed documentation. The description should be more 
than a link to an issue.  -->
Replace by.text with by.id wherever possible in the militaryInfo and veteranStatusCard tests.

## Screenshots/Video
<!-- Add screenshots or video as needed. Before/after if changes are to be compared by reviewers.
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Toggle: <details><summary></summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>
-->

## Testing
<!-- What testing was done to verify the changes (local/unit)? What testing remains? Note edge cases, or special
situations that could not be tested during development. -->

- [ ] Tested on iOS <!-- simulator is fine -->
- [ ] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
<!-- What should reviewers look for? Copy/paste Acceptance Criteria from ticket -->

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [ ] PR is connected to issue(s)
- [ ] Tests are included to cover this change (when possible)
- [ ] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [ ] No secrets or API keys are checked in
- [ ] All imports are absolute (no relative imports)
- [ ] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
