### PR TITLE
bug/9737-message-failure-snackbar-reappearance

### DIFF
--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/ReplyMessage/ReplyMessage.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/ReplyMessage/ReplyMessage.tsx
@@ -258,27 +258,29 @@ function ReplyMessage({ navigation, route }: ReplyMessageProps) {
           navigateTo('SecureMessaging', { activeTab: 0 })
         },
         onError: () => {
-          if (sendMessageError && isErrorObject(sendMessageErrorDetails)) {
-            if (hasErrorCode(SecureMessagingErrorCodesConstants.TRIAGE_ERROR, sendMessageErrorDetails)) {
-              setReplyTriageError(true)
-            } else {
-              showSnackBar(
-                snackbarSentMessages.errorMsg,
-                dispatch,
-                // passing messageDataRef to ensure we have the latest messageData
-                () =>
-                  sendMessage(
-                    {
-                      messageData: messageDataRef.current,
-                      uploads: attachmentsList,
-                      replyToID: message.messageId,
-                    },
-                    mutateOptions,
-                  ),
-                false,
-                true,
-              )
-            }
+          if (
+            sendMessageError &&
+            isErrorObject(sendMessageErrorDetails) &&
+            hasErrorCode(SecureMessagingErrorCodesConstants.TRIAGE_ERROR, sendMessageErrorDetails)
+          ) {
+            setReplyTriageError(true)
+          } else {
+            showSnackBar(
+              snackbarSentMessages.errorMsg,
+              dispatch,
+              // passing messageDataRef to ensure we have the latest messageData
+              () =>
+                sendMessage(
+                  {
+                    messageData: messageDataRef.current,
+                    uploads: attachmentsList,
+                    replyToID: message.messageId,
+                  },
+                  mutateOptions,
+                ),
+              false,
+              true,
+            )
           }
         },
       }

--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/ReplyMessage/ReplyMessage.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/ReplyMessage/ReplyMessage.tsx
@@ -115,6 +115,16 @@ function ReplyMessage({ navigation, route }: ReplyMessageProps) {
   const receiverID = message?.senderId
   const subjectHeader = formatSubject(category, subject, t)
 
+  const messageData = {
+    body: messageReply,
+    category: category,
+    subject: subject,
+    recipient_id: receiverID,
+  } as SecureMessagingFormData
+  // Ref for use in snackbar callbacks to ensure we have the latest messageData
+  const messageDataRef = useRef<SecureMessagingFormData>(messageData)
+  messageDataRef.current = messageData
+
   const snackbarMessages: SnackbarMessages = {
     successMsg: t('secureMessaging.draft.saved'),
     errorMsg: t('secureMessaging.draft.saved.error'),
@@ -140,48 +150,6 @@ function ReplyMessage({ navigation, route }: ReplyMessageProps) {
       setOnSendClicked(true)
     }
   }, [saveDraftConfirmFailed])
-
-  useEffect(() => {
-    if (sendMessageError && isErrorObject(sendMessageErrorDetails)) {
-      if (hasErrorCode(SecureMessagingErrorCodesConstants.TRIAGE_ERROR, sendMessageErrorDetails)) {
-        setReplyTriageError(true)
-      } else {
-        const messageData = {
-          body: messageReply,
-          category: category,
-          subject: subject,
-          recipient_id: receiverID,
-        } as SecureMessagingFormData
-        const mutateOptions = {
-          onSuccess: () => {
-            showSnackBar(snackbarSentMessages.successMsg, dispatch, undefined, true, false, true)
-            logAnalyticsEvent(Events.vama_sm_send_message(messageData.category, undefined))
-            navigateTo('SecureMessaging', { activeTab: 0 })
-          },
-        }
-        const params: SendMessageParameters = {
-          messageData: messageData,
-          uploads: attachmentsList,
-          replyToID: message.messageId,
-        }
-        showSnackBar(snackbarSentMessages.errorMsg, dispatch, () => sendMessage(params, mutateOptions), false, true)
-      }
-    }
-  }, [
-    dispatch,
-    sendMessageError,
-    sendMessageErrorDetails,
-    snackbarSentMessages.successMsg,
-    snackbarSentMessages.errorMsg,
-    attachmentsList,
-    category,
-    messageReply,
-    receiverID,
-    subject,
-    message.messageId,
-    navigateTo,
-    sendMessage,
-  ])
 
   /**
    * Intercept navigation action before leaving the screen, used the handle OS swipe/hardware back behavior
@@ -241,14 +209,14 @@ function ReplyMessage({ navigation, route }: ReplyMessageProps) {
   ]
 
   const sendReplyOrSaveDraft = (): void => {
-    const messageData = { body: messageReply, category } as SecureMessagingFormData
+    const reducedMessageData = { body: messageReply, category } as SecureMessagingFormData
     if (onSaveDraftClicked) {
       saveDraftWithAttachmentAlert(draftAttachmentAlert, attachmentsList, t, () => {
-        const params: SaveDraftParameters = { messageData: messageData, replyID: message.messageId }
+        const params: SaveDraftParameters = { messageData: reducedMessageData, replyID: message.messageId }
         const mutateOptions = {
           onSuccess: () => {
             showSnackBar(snackbarMessages.successMsg, dispatch, undefined, true, false, true)
-            logAnalyticsEvent(Events.vama_sm_save_draft(messageData.category))
+            logAnalyticsEvent(Events.vama_sm_save_draft(reducedMessageData.category))
             queryClient.invalidateQueries({
               queryKey: [secureMessagingKeys.folderMessages, SecureMessagingSystemFolderIdConstants.DRAFTS],
             })
@@ -260,7 +228,24 @@ function ReplyMessage({ navigation, route }: ReplyMessageProps) {
             })
           },
           onError: () => {
-            showSnackBar(snackbarMessages.errorMsg, dispatch, () => saveDraft(params, mutateOptions), false, true)
+            showSnackBar(
+              snackbarMessages.errorMsg,
+              dispatch,
+              // passing messageDataRef to ensure we have the latest messageData
+              () =>
+                saveDraft(
+                  {
+                    messageData: {
+                      body: messageDataRef.current.body,
+                      category: messageDataRef.current.category,
+                    },
+                    replyID: message.messageId,
+                  },
+                  mutateOptions,
+                ),
+              false,
+              true,
+            )
           },
         }
         saveDraft(params, mutateOptions)
@@ -271,6 +256,30 @@ function ReplyMessage({ navigation, route }: ReplyMessageProps) {
           showSnackBar(snackbarSentMessages.successMsg, dispatch, undefined, true, false, true)
           logAnalyticsEvent(Events.vama_sm_send_message(messageData.category, undefined))
           navigateTo('SecureMessaging', { activeTab: 0 })
+        },
+        onError: () => {
+          if (sendMessageError && isErrorObject(sendMessageErrorDetails)) {
+            if (hasErrorCode(SecureMessagingErrorCodesConstants.TRIAGE_ERROR, sendMessageErrorDetails)) {
+              setReplyTriageError(true)
+            } else {
+              showSnackBar(
+                snackbarSentMessages.errorMsg,
+                dispatch,
+                // passing messageDataRef to ensure we have the latest messageData
+                () =>
+                  sendMessage(
+                    {
+                      messageData: messageDataRef.current,
+                      uploads: attachmentsList,
+                      replyToID: message.messageId,
+                    },
+                    mutateOptions,
+                  ),
+                false,
+                true,
+              )
+            }
+          }
         },
       }
       const params: SendMessageParameters = {

--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/StartNewMessage/StartNewMessage.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/StartNewMessage/StartNewMessage.tsx
@@ -128,53 +128,20 @@ function StartNewMessage({ navigation, route }: StartNewMessageProps) {
   const scrollViewRef = useRef<ScrollView>(null)
   const [isDiscarded, composeCancelConfirmation] = useComposeCancelConfirmation()
 
-  useEffect(() => {
-    if (sendMessageError && isErrorObject(sendMessageErrorDetails)) {
-      if (hasErrorCode(SecureMessagingErrorCodesConstants.TRIAGE_ERROR, sendMessageErrorDetails)) {
-        setReplyTriageError(true)
-      } else {
-        const messageData = {
-          recipient_id: parseInt(to, 10),
-          category: category as CategoryTypes,
-          body: message,
-          subject,
-        } as SecureMessagingFormData
-        const mutateOptions = {
-          onSuccess: () => {
-            showSnackBar(snackbarSentMessages.successMsg, dispatch, undefined, true, false, true)
-            logAnalyticsEvent(Events.vama_sm_send_message(messageData.category, undefined))
-            navigateTo('SecureMessaging', { activeTab: 0 })
-          },
-        }
-        const params: SendMessageParameters = { messageData: messageData, uploads: attachmentsList }
-        showSnackBar(snackbarSentMessages.errorMsg, dispatch, () => sendMessage(params, mutateOptions), false, true)
-      }
-    }
-  }, [
-    dispatch,
-    sendMessageError,
-    sendMessageErrorDetails,
-    snackbarSentMessages.successMsg,
-    snackbarSentMessages.errorMsg,
-    attachmentsList,
-    category,
-    message,
-    to,
+  const messageData = {
+    recipient_id: parseInt(to, 10),
+    category: category as CategoryTypes,
+    body: message,
     subject,
-    navigateTo,
-    sendMessage,
-  ])
+  } as SecureMessagingFormData
+  // Must pass ref to snackbar callback, otherwise messageData will be stale
+  const messageDataRef = useRef<SecureMessagingFormData>(messageData)
+  messageDataRef.current = messageData
 
   const noRecipientsReceived = !recipients || recipients.length === 0
   const noProviderError = noRecipientsReceived && hasLoadedRecipients
 
   const goToCancel = () => {
-    const messageData = {
-      recipient_id: parseInt(to, 10),
-      category: category as CategoryTypes,
-      body: message,
-      subject,
-    } as SecureMessagingFormData
     composeCancelConfirmation({
       origin: FormHeaderTypeConstants.compose,
       draftMessageID: undefined,
@@ -329,13 +296,6 @@ function StartNewMessage({ navigation, route }: StartNewMessageProps) {
   }
 
   const onMessageSendOrSave = (): void => {
-    const messageData = {
-      recipient_id: parseInt(to, 10),
-      category: category as CategoryTypes,
-      body: message,
-      subject,
-    } as SecureMessagingFormData
-
     if (onSaveDraftClicked) {
       saveDraftWithAttachmentAlert(draftAttachmentAlert, attachmentsList, t, () => {
         const params: SaveDraftParameters = { messageData: messageData }
@@ -354,7 +314,14 @@ function StartNewMessage({ navigation, route }: StartNewMessageProps) {
             })
           },
           onError: () => {
-            showSnackBar(snackbarMessages.errorMsg, dispatch, () => saveDraft(params, mutateOptions), false, true)
+            showSnackBar(
+              snackbarMessages.errorMsg,
+              dispatch,
+              // passing messageDataRef to ensure we have the latest messageData
+              () => saveDraft({ messageData: messageDataRef.current }, mutateOptions),
+              false,
+              true,
+            )
           },
         }
         saveDraft(params, mutateOptions)
@@ -365,6 +332,24 @@ function StartNewMessage({ navigation, route }: StartNewMessageProps) {
           showSnackBar(snackbarSentMessages.successMsg, dispatch, undefined, true, false, true)
           logAnalyticsEvent(Events.vama_sm_send_message(messageData.category, undefined))
           navigateTo('SecureMessaging', { activeTab: 0 })
+        },
+        onError: () => {
+          if (
+            sendMessageError &&
+            isErrorObject(sendMessageErrorDetails) &&
+            hasErrorCode(SecureMessagingErrorCodesConstants.TRIAGE_ERROR, sendMessageErrorDetails)
+          ) {
+            setReplyTriageError(true)
+          } else {
+            showSnackBar(
+              snackbarSentMessages.errorMsg,
+              dispatch,
+              // passing messageDataRef to ensure we have the latest messageData
+              () => sendMessage({ messageData: messageDataRef.current, uploads: attachmentsList }, mutateOptions),
+              false,
+              true,
+            )
+          }
         },
       }
       const params: SendMessageParameters = { messageData: messageData, uploads: attachmentsList }

--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/StartNewMessage/StartNewMessage.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/StartNewMessage/StartNewMessage.tsx
@@ -334,19 +334,21 @@ function StartNewMessage({ navigation, route }: StartNewMessageProps) {
           navigateTo('SecureMessaging', { activeTab: 0 })
         },
         onError: () => {
-          if (sendMessageError && isErrorObject(sendMessageErrorDetails)) {
-            if (hasErrorCode(SecureMessagingErrorCodesConstants.TRIAGE_ERROR, sendMessageErrorDetails)) {
-              setReplyTriageError(true)
-            } else {
-              showSnackBar(
-                snackbarSentMessages.errorMsg,
-                dispatch,
-                // passing messageDataRef to ensure we have the latest messageData
-                () => sendMessage({ messageData: messageDataRef.current, uploads: attachmentsList }, mutateOptions),
-                false,
-                true,
-              )
-            }
+          if (
+            sendMessageError &&
+            isErrorObject(sendMessageErrorDetails) &&
+            hasErrorCode(SecureMessagingErrorCodesConstants.TRIAGE_ERROR, sendMessageErrorDetails)
+          ) {
+            setReplyTriageError(true)
+          } else {
+            showSnackBar(
+              snackbarSentMessages.errorMsg,
+              dispatch,
+              // passing messageDataRef to ensure we have the latest messageData
+              () => sendMessage({ messageData: messageDataRef.current, uploads: attachmentsList }, mutateOptions),
+              false,
+              true,
+            )
           }
         },
       }

--- a/VAMobile/src/screens/HealthScreen/SecureMessaging/StartNewMessage/StartNewMessage.tsx
+++ b/VAMobile/src/screens/HealthScreen/SecureMessaging/StartNewMessage/StartNewMessage.tsx
@@ -134,7 +134,7 @@ function StartNewMessage({ navigation, route }: StartNewMessageProps) {
     body: message,
     subject,
   } as SecureMessagingFormData
-  // Must pass ref to snackbar callback, otherwise messageData will be stale
+  // Ref for use in snackbar callbacks to ensure we have the latest messageData
   const messageDataRef = useRef<SecureMessagingFormData>(messageData)
   messageDataRef.current = messageData
 
@@ -334,21 +334,19 @@ function StartNewMessage({ navigation, route }: StartNewMessageProps) {
           navigateTo('SecureMessaging', { activeTab: 0 })
         },
         onError: () => {
-          if (
-            sendMessageError &&
-            isErrorObject(sendMessageErrorDetails) &&
-            hasErrorCode(SecureMessagingErrorCodesConstants.TRIAGE_ERROR, sendMessageErrorDetails)
-          ) {
-            setReplyTriageError(true)
-          } else {
-            showSnackBar(
-              snackbarSentMessages.errorMsg,
-              dispatch,
-              // passing messageDataRef to ensure we have the latest messageData
-              () => sendMessage({ messageData: messageDataRef.current, uploads: attachmentsList }, mutateOptions),
-              false,
-              true,
-            )
+          if (sendMessageError && isErrorObject(sendMessageErrorDetails)) {
+            if (hasErrorCode(SecureMessagingErrorCodesConstants.TRIAGE_ERROR, sendMessageErrorDetails)) {
+              setReplyTriageError(true)
+            } else {
+              showSnackBar(
+                snackbarSentMessages.errorMsg,
+                dispatch,
+                // passing messageDataRef to ensure we have the latest messageData
+                () => sendMessage({ messageData: messageDataRef.current, uploads: attachmentsList }, mutateOptions),
+                false,
+                true,
+              )
+            }
           }
         },
       }


### PR DESCRIPTION
## Description of Change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, 
need to know about this PR in order to understand why this PR was created? This could include dependencies 
introduced, changes in behavior, pointers to more detailed documentation. The description should be more 
than a link to an issue.  -->

Refactor the StartNewMessage and ReplyMessage components to use onError instead of useEffect. This prevents the error snackbar from reappearing on every render after the error occurs, including while typing. I had to use refs to keep the message data up to date inside the snackbar callback.

Actions where the changes apply:

- Send message
- Save message draft
- Reply to message
- Save reply draft

## Screenshots/Video
<!-- Add screenshots or video as needed. Before/after if changes are to be compared by reviewers.
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Toggle: <details><summary></summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>
-->

Before:


https://github.com/user-attachments/assets/39768129-e76d-4e33-91f9-d7c557f69b54



After:


https://github.com/user-attachments/assets/e9da6577-4c57-4318-8e7b-a8b4dbe2121d



## Testing
<!-- What testing was done to verify the changes (local/unit)? What testing remains? Note edge cases, or special
situations that could not be tested during development. -->

- [ ] Tested on iOS <!-- simulator is fine -->
- [ ] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
<!-- What should reviewers look for? Copy/paste Acceptance Criteria from ticket -->
- Snack bar should only appear when message is attempted to be sent

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [ ] PR is connected to issue(s)
- [ ] Tests are included to cover this change (when possible)
- [ ] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [ ] No secrets or API keys are checked in
- [ ] All imports are absolute (no relative imports)
- [ ] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
