### PR TITLE
bug/9735-chanel-pr-label-automation-should-remove-other-labels-when-ready-to-merge

### DIFF
--- a/.github/workflows/label_pull_request_onReview.yml
+++ b/.github/workflows/label_pull_request_onReview.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Remove old labels and add FE-Changes Requested
         run: |
-          gh pr edit ${{ github.event.pull_request.number }}  --remove-label "FE-Needs Review,FE-With QA" --add-label "FE-Changes Requested"
+          gh pr edit ${{ github.event.pull_request.number }}  --remove-label "FE-With QA" --add-label "FE-Changes Requested"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -29,9 +29,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Remove old labels and add FE-Needs Review
+      - name: Remove old labels
         run: |
-          gh pr edit ${{ github.event.pull_request.number }}  --remove-label "FE-Changes Requested" --add-label "FE-Needs Review"
+          gh pr edit ${{ github.event.pull_request.number }}  --remove-label "FE-Changes Requested"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -59,10 +59,10 @@ jobs:
               if [[ $(jq '[.[] | select(. | IN("timwright12", "rbontrager", "DJUltraTom", "TKDickson"))] | length' <<< "$approvals") -gt 0 ]]
                 then
                 echo 'This PR has QA approval and one other'
-                gh pr edit ${{ github.event.pull_request.number }}  --remove-label "FE-Needs Review,FE-With QA" --add-label "FE-Ready to Merge"
+                gh pr edit ${{ github.event.pull_request.number }}  --remove-label "FE-With QA" --add-label "FE-Ready to Merge"
               else 
                 echo 'This PR requires QA approval'
-                gh pr edit ${{ github.event.pull_request.number }}  --remove-label "FE-Needs Review" --add-label "FE-With QA"
+                gh pr edit ${{ github.event.pull_request.number }}  --add-label "FE-With QA"
               fi
           else
             echo 'This PR requires 2 approvals, including one QA approval'


### PR DESCRIPTION
## Description of Change
The new PR label automation (for when PRs 'advance' through our review process) currently adds the "FE-Ready to Merge" label at the right spot, but it doesn't remove other labels. I'm seeing PRs consistently with both "FE-With QA" and "FE-Ready to Merge" labels.

IDK if it would do the same thing with any other "FE-XXXX" labels still on there (even if those cases are less likely)

## Screenshots/Video
<!-- Add screenshots or video as needed. Before/after if changes are to be compared by reviewers.
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Toggle: <details><summary></summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>
-->

## Testing
<!-- What testing was done to verify the changes (local/unit)? What testing remains? Note edge cases, or special
situations that could not be tested during development. -->

- [ ] Tested on iOS <!-- simulator is fine -->
- [ ] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
<!-- What should reviewers look for? Copy/paste Acceptance Criteria from ticket -->

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [ ] PR is connected to issue(s)
- [ ] Tests are included to cover this change (when possible)
- [ ] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [ ] No secrets or API keys are checked in
- [ ] All imports are absolute (no relative imports)
- [ ] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
