### PR TITLE
bug/9964-chanel-ios-2-39-ci-failure

### DIFF
--- a/VAMobile/ios/fastlane/Fastfile
+++ b/VAMobile/ios/fastlane/Fastfile
@@ -109,7 +109,7 @@ platform :ios do
         slack_release_success(version.version_string, "iOS")
       end
     rescue => e
-      slack_release_error(version, e)
+      slack_release_error(version, "iOS", e)
     end
   end
 


### PR DESCRIPTION

## Description of Change
1- The first error we're encountering indicates that the method slack_release_error(version, e) in our Fastlane Fastfile iOS is being called with two arguments, but the method is defined to expect 3 to 4 arguments.
2- We are getting a warning on the [go live run](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/runs/11459719112/job/31884862430) about ssh key associated with IsraelleHub github username

<img width="1137" alt="Screenshot 2024-10-22 at 12 29 13 PM" src="https://github.com/user-attachments/assets/3cdc6771-d4da-4516-a6c8-06109de42002">

<img width="1145" alt="Screenshot 2024-10-22 at 10 30 26 AM" src="https://github.com/user-attachments/assets/df6214f0-908d-410c-9a2a-d3ba0c60b547">


## Testing
<!-- What testing was done to verify the changes (local/unit)? What testing remains? Note edge cases, or special
situations that could not be tested during development. -->

- [ ] Tested on iOS <!-- simulator is fine -->
- [ ] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
<!-- What should reviewers look for? Copy/paste Acceptance Criteria from ticket -->

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [ ] PR is connected to issue(s)
- [ ] Tests are included to cover this change (when possible)
- [ ] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [ ] No secrets or API keys are checked in
- [ ] All imports are absolute (no relative imports)
- [ ] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
