### PR TITLE
bug/7801-SMButtonLinkUpdates

### DIFF
--- a/VAMobile/src/components/Menu/MenuView.tsx
+++ b/VAMobile/src/components/Menu/MenuView.tsx
@@ -136,7 +136,7 @@ const MenuView: FC<MenuViewProps> = ({ actions }) => {
   return (
     <>
       <ElementToStick ref={elementRef} style={elementToStickStyle} />
-      <Pressable onPress={showMenu} style={launchBtnStyle} accessibilityLabel={'menu'} accessibilityRole={'button'}>
+      <Pressable onPress={showMenu} style={launchBtnStyle} accessibilityLabel={t('more')} accessibilityRole={'link'}>
         <IconWithText name="MoreHoriz" fill={currentTheme.colors.icon.active} label={t('more')} />
       </Pressable>
 


### PR DESCRIPTION
## Description of Change
Updated the a11yLabel and Role from menu and button to more and link

## Screenshots/Video
N/A

## Testing
Yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
Recommended change: Should be a link not a button. Also currently says "menu, button". This should say "more, link" or "more, menu, link".


## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
