### PR TITLE
bug/revert-9979-chanel-update-fatlane-version-on-ios-and-android

### DIFF
--- a/VAMobile/android/Gemfile.lock
+++ b/VAMobile/android/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
     fastimage (2.3.1)
-    fastlane (2.225.0)
+    fastlane (2.218.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)

--- a/VAMobile/ios/Gemfile.lock
+++ b/VAMobile/ios/Gemfile.lock
@@ -126,7 +126,7 @@ GEM
     faraday_middleware (1.2.1)
       faraday (~> 1.0)
     fastimage (2.3.1)
-    fastlane (2.225.0)
+    fastlane (2.224.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)


### PR DESCRIPTION
Reverts department-of-veterans-affairs/va-mobile-app#9979
Note: We are rolling back to the previous version because the recent fastlane upgrade to 2.225 on iOS and android was breaking detox and also to mitigate the risk of android failing.
- Eventhough we are rolling it back, we will still need to upgrade fastlane for security compliance.
- --------------------------------------------------------------
The recent [bug](https://app.zenhub.com/workspaces/va-mobile-60f1a34998bc75000f2a489f/issues/gh/department-of-veterans-affairs/va-mobile-app/9887) on android 2.37 and 2.38 not being released got us doing more investigation and it was found that our fastlane is out of date. Android more-so than iOS. Latest release is 2.225. iOS is on 2.224 and android on 2.218
Even though the workflows [build_android ](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/.github/workflows/build_android.yml)and [build_iOS.yml ](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/.github/workflows/build_ios.yml)have the update of fastlane integrated, it doesn't always update it.
This will be a reccurring update every 2 months for risk mitigations