### PR TITLE
bug/10115-VALogoResizing

### DIFF
--- a/VAMobile/src/components/VALogo/VALogo.tsx
+++ b/VAMobile/src/components/VALogo/VALogo.tsx
@@ -14,7 +14,7 @@ export const VALogo: FC<VALogoProps> = ({ variant, testID }) => {
   const theme = useTheme()
 
   const logoProps: ImageProps = {
-    width: 254,
+    width: 270,
     height: 57,
   }
 


### PR DESCRIPTION
## Description of Change
Found out the issue was the hard set width of 254 was cutting off the s, so I bumped it to 270 and it is no longer cut off.

## Screenshots/Video
<img width="479" alt="Screenshot 2024-11-07 at 1 51 55 PM" src="https://github.com/user-attachments/assets/e3bd8279-52ad-4a4a-8ca1-93b6dde617d4">


## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
Space is extended, so there is no more cutoff
 Nothing else is affected (a11y stays the same, etc)
 VQA with any designer

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
