### PR TITLE
updated

### DIFF
--- a/VAMobile/src/components/VABulletList.tsx
+++ b/VAMobile/src/components/VABulletList.tsx
@@ -91,7 +91,11 @@ const VABulletList: FC<VABulletListProps> = ({ listOfText, paragraphSpacing }) =
             accessible={true}
             accessibilityRole="text">
             <Box mr={20} mt={12}>
-              <Box backgroundColor={'bullet'} height={6} width={6} />
+              <Box
+                backgroundColor={color === 'primaryContrast' ? 'brandedMainBackground' : 'bullet'}
+                height={6}
+                width={6}
+              />
             </Box>
             <TextView {...textViewProps} accessibilityLabel={a11yLabel}>
               {!!boldedTextPrefix && <TextView variant="MobileBodyBold">{boldedTextPrefix}</TextView>}


### PR DESCRIPTION
## Description of Change
Updated VABulletList color to match text color for the onboarding screens and any other instances of it being on top of the blue background

## Screenshots/Video
<img width="479" alt="Screenshot 2024-11-07 at 2 21 40 PM" src="https://github.com/user-attachments/assets/b014dfb6-bc01-4bd9-b1b0-9adeaab83285">
<img width="479" alt="Screenshot 2024-11-07 at 2 21 45 PM" src="https://github.com/user-attachments/assets/5b24ee56-c850-4b96-9d22-804b5bb1ef81">


## Testing
yarn test

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
Confirmed that dark mode has white bullet points (aka sufficient contrast) and that this is new in this release. I'm guessing it was caused by the icon conversion [(ticket 9779).](https://github.com/department-of-veterans-affairs/va-mobile-app/issues/9779)

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
