### PR TITLE
jchore: update personal info screen tests with i18n

### DIFF
--- a/VAMobile/src/screens/HomeScreen/ProfileScreen/PersonalInformationScreen/GenderIdentityScreen/GenderIdentityScreen.test.tsx
+++ b/VAMobile/src/screens/HomeScreen/ProfileScreen/PersonalInformationScreen/GenderIdentityScreen/GenderIdentityScreen.test.tsx
@@ -20,7 +20,7 @@ context('GenderIdentityScreen', () => {
           TM: 'Transgender man',
           TF: 'Transgender woman',
           F: 'Woman',
-          N: t('personalInformation.genderIdentity.preferNotToAnswer'),
+          N: 'Prefer not to answer',
           O: 'A gender not listed here',
         },
       },
@@ -67,7 +67,7 @@ context('GenderIdentityScreen', () => {
     await waitFor(() =>
       expect(
         screen.getByText(
-          'You can change your selection at any time. If you decide you no longer want to share your gender identity, select Prefer not to answer.',
+          `${t('personalInformation.genderIdentity.changeSelection')}${t('personalInformation.genderIdentity.preferNotToAnswer')}.`,
         ),
       ).toBeTruthy(),
     )

--- a/VAMobile/src/screens/HomeScreen/ProfileScreen/PersonalInformationScreen/GenderIdentityScreen/GenderIdentityScreen.test.tsx
+++ b/VAMobile/src/screens/HomeScreen/ProfileScreen/PersonalInformationScreen/GenderIdentityScreen/GenderIdentityScreen.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { fireEvent, screen } from '@testing-library/react-native'
+import { t } from 'i18next'
 
 import * as api from 'store/api'
 import { context, mockNavProps, render, waitFor, when } from 'testUtils'
@@ -19,7 +20,7 @@ context('GenderIdentityScreen', () => {
           TM: 'Transgender man',
           TF: 'Transgender woman',
           F: 'Woman',
-          N: 'Prefer not to answer',
+          N: t('personalInformation.genderIdentity.preferNotToAnswer'),
           O: 'A gender not listed here',
         },
       },
@@ -62,7 +63,7 @@ context('GenderIdentityScreen', () => {
       .calledWith('/v0/user/gender_identity/edit')
       .mockResolvedValue(genderIdentityOptionsPayload)
     initializeTestInstance()
-    await waitFor(() => expect(screen.getByText('Gender identity')).toBeTruthy())
+    await waitFor(() => expect(screen.getByText(t('personalInformation.genderIdentity.title'))).toBeTruthy())
     await waitFor(() =>
       expect(
         screen.getByText(
@@ -75,12 +76,14 @@ context('GenderIdentityScreen', () => {
     await waitFor(() => expect(screen.getByRole('radio', { name: 'Transgender man' })).toBeTruthy())
     await waitFor(() => expect(screen.getByRole('radio', { name: 'Transgender woman' })).toBeTruthy())
     await waitFor(() => expect(screen.getByRole('radio', { name: 'Woman' })).toBeTruthy())
-    await waitFor(() => expect(screen.getByRole('radio', { name: 'Prefer not to answer' })).toBeTruthy())
-    await waitFor(() => expect(screen.getByRole('radio', { name: 'A gender not listed here' })).toBeTruthy())
     await waitFor(() =>
       expect(
-        screen.getByRole('link', { name: 'What to know before you decide to share your gender identity' }),
+        screen.getByRole('radio', { name: t('personalInformation.genderIdentity.preferNotToAnswer') }),
       ).toBeTruthy(),
+    )
+    await waitFor(() => expect(screen.getByRole('radio', { name: 'A gender not listed here' })).toBeTruthy())
+    await waitFor(() =>
+      expect(screen.getByRole('link', { name: t('personalInformation.genderIdentity.whatToKnow.title') })).toBeTruthy(),
     )
   })
 
@@ -92,8 +95,8 @@ context('GenderIdentityScreen', () => {
       .mockResolvedValue(genderIdentityOptionsPayload)
     initializeTestInstance()
 
-    await waitFor(() => fireEvent.press(screen.getByRole('button', { name: 'Save' })))
-    await waitFor(() => expect(screen.queryByText('Select an option')).toBeTruthy())
+    await waitFor(() => fireEvent.press(screen.getByRole('button', { name: t('save') })))
+    await waitFor(() => expect(screen.queryByText(t('selectOption'))).toBeTruthy())
   })
 
   it('renders the ErrorComponent when an error occurs', async () => {
@@ -105,7 +108,7 @@ context('GenderIdentityScreen', () => {
 
     initializeTestInstance()
     await waitFor(() => {
-      expect(screen.getByRole('header', { name: "The app can't be loaded." })).toBeTruthy()
+      expect(screen.getByRole('header', { name: t('errors.networkConnection.header') })).toBeTruthy()
     })
   })
 })

--- a/VAMobile/src/screens/HomeScreen/ProfileScreen/PersonalInformationScreen/HowDoIUpdateScreen/HowDoIUpdateScreen.test.tsx
+++ b/VAMobile/src/screens/HomeScreen/ProfileScreen/PersonalInformationScreen/HowDoIUpdateScreen/HowDoIUpdateScreen.test.tsx
@@ -2,8 +2,10 @@ import React from 'react'
 import { Alert } from 'react-native'
 
 import { fireEvent, screen } from '@testing-library/react-native'
+import { t } from 'i18next'
 
 import { context, mockNavProps, render } from 'testUtils'
+import { displayedTextPhoneNumber } from 'utils/formattingUtils'
 
 import HowDoIUpdateScreen from './HowDoIUpdateScreen'
 
@@ -24,56 +26,32 @@ context('HowDoIUpdateScreen', () => {
 
   it('initializes correctly for DOB', () => {
     initializeTestInstance('DOB')
-    expect(screen.getByRole('header', { name: 'How to fix an error in your date of birth' })).toBeTruthy()
-    expect(
-      screen.getByText(
-        "If our records have an error in your date of birth, you can request a correction. Here's how to request a correction:",
-      ),
-    ).toBeTruthy()
-    expect(
-      screen.getByText("If you're enrolled in the VA health care program, contact your nearest VA medical center."),
-    ).toBeTruthy()
-    expect(screen.getByRole('link', { name: 'Find nearest VA medical center' })).toBeTruthy()
-    expect(
-      screen.getByText(
-        "If you receive VA benefits but aren’t enrolled in VA health care, call us. We're here Monday through Friday, 8:00 AM to 9:00 PM ET.",
-      ),
-    ).toBeTruthy()
-    expect(screen.getByRole('link', { name: '800-827-1000' })).toBeTruthy()
-    expect(screen.getByRole('link', { name: 'TTY: 711' })).toBeTruthy()
+    expect(screen.getByRole('header', { name: t('howDoIUpdate.dateOfBirth.title') })).toBeTruthy()
+    expect(screen.getByText(t('howDoIUpdate.dateOfBirth.body'))).toBeTruthy()
+    expect(screen.getByText(t('howDoIUpdate.ifEnrolledInVAHealth'))).toBeTruthy()
+    expect(screen.getByRole('link', { name: t('howDoIUpdate.findYourNearestVAMedicalCenter') })).toBeTruthy()
+    expect(screen.getByText(t('howDoIUpdate.ifNotEnrolledInVAHealth'))).toBeTruthy()
+    expect(screen.getByRole('link', { name: displayedTextPhoneNumber(t('8008271000')) })).toBeTruthy()
+    expect(screen.getByRole('link', { name: t('contactVA.tty.displayText') })).toBeTruthy()
   })
 
   it('initializes correctly for name', () => {
     initializeTestInstance('name')
-    expect(screen.getByRole('header', { name: 'How to update or fix an error in your legal name' })).toBeTruthy()
-    expect(
-      screen.getByText(
-        "If you've changed your legal name, you'll need to tell us so we can change your name in our records.",
-      ),
-    ).toBeTruthy()
-    expect(screen.getByRole('link', { name: 'Learn how to change your legal name on file with the VA' })).toBeTruthy()
-    expect(
-      screen.getByText(
-        "If our records have a misspelling or other error in your name, you can request a correction. Here's how to request a correction:",
-      ),
-    ).toBeTruthy()
-    expect(
-      screen.getByText("If you're enrolled in the VA health care program, contact your nearest VA medical center."),
-    ).toBeTruthy()
-    expect(screen.getByRole('link', { name: 'Find nearest VA medical center' })).toBeTruthy()
-    expect(
-      screen.getByText(
-        "If you receive VA benefits but aren’t enrolled in VA health care, call us. We're here Monday through Friday, 8:00 AM to 9:00 PM ET.",
-      ),
-    ).toBeTruthy()
-    expect(screen.getByRole('link', { name: '800-827-1000' })).toBeTruthy()
-    expect(screen.getByRole('link', { name: 'TTY: 711' })).toBeTruthy()
+    expect(screen.getByRole('header', { name: t('howDoIUpdate.name.title') })).toBeTruthy()
+    expect(screen.getByText(t('howDoIUpdate.name.legalName'))).toBeTruthy()
+    expect(screen.getByRole('link', { name: t('howDoIUpdate.learnToChangeLegalName') })).toBeTruthy()
+    expect(screen.getByText(t('howDoIUpdate.name.incorrectRecords'))).toBeTruthy()
+    expect(screen.getByText(t('howDoIUpdate.ifEnrolledInVAHealth'))).toBeTruthy()
+    expect(screen.getByRole('link', { name: t('howDoIUpdate.findYourNearestVAMedicalCenter') })).toBeTruthy()
+    expect(screen.getByText(t('howDoIUpdate.ifNotEnrolledInVAHealth'))).toBeTruthy()
+    expect(screen.getByRole('link', { name: displayedTextPhoneNumber(t('8008271000')) })).toBeTruthy()
+    expect(screen.getByRole('link', { name: t('contactVA.tty.displayText') })).toBeTruthy()
   })
 
   describe('when the find VA location link is clicked', () => {
     it('should show alert', () => {
       initializeTestInstance('DOB')
-      fireEvent.press(screen.getByRole('link', { name: 'Find nearest VA medical center' }))
+      fireEvent.press(screen.getByRole('link', { name: t('howDoIUpdate.findYourNearestVAMedicalCenter') }))
       expect(Alert.alert).toBeCalled()
     })
   })

--- a/VAMobile/src/screens/HomeScreen/ProfileScreen/PersonalInformationScreen/PersonalInformationScreen.test.tsx
+++ b/VAMobile/src/screens/HomeScreen/ProfileScreen/PersonalInformationScreen/PersonalInformationScreen.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { screen, waitFor } from '@testing-library/react-native'
+import { t } from 'i18next'
 
 import { personalInformationKeys } from 'api/personalInformation/queryKeys'
 import { DemographicsPayload, GenderIdentityOptionsPayload, UserDemographics } from 'api/types'
@@ -28,7 +29,7 @@ when(get as jest.Mock)
           tm: 'Transgender Man',
           tf: 'Transgender Woman',
           f: 'Woman',
-          n: 'Prefer not to answer',
+          n: t('personalInformation.genderIdentity.preferNotToAnswer'),
           o: 'A gender not listed here',
         },
       },
@@ -63,20 +64,18 @@ context('PersonalInformationScreen', () => {
 
   it('renders correctly', async () => {
     renderWithData()
-    expect(screen.getByText('Loading your personal information...')).toBeTruthy()
-    await waitFor(() => expect(screen.getByLabelText('Personal information')).toBeTruthy())
+    expect(screen.getByText(t('personalInformation.loading'))).toBeTruthy()
+    await waitFor(() => expect(screen.getByLabelText(t('personalInformation.title'))).toBeTruthy())
+    await waitFor(() => expect(screen.getByText(t('contactInformation.editNote'))).toBeTruthy())
     await waitFor(() =>
-      expect(screen.getByText('Any updates you make here will also update in your VA.gov profile.')).toBeTruthy(),
+      expect(screen.getByRole('link', { name: t('personalInformation.howToFixLegalName') })).toBeTruthy(),
     )
+    await waitFor(() => expect(screen.getByText(t('personalInformation.dateOfBirth'))).toBeTruthy())
     await waitFor(() =>
-      expect(screen.getByRole('link', { name: 'How to update or fix an error in your legal name' })).toBeTruthy(),
+      expect(screen.getByRole('link', { name: t('personalInformation.howToFixDateOfBirth') })).toBeTruthy(),
     )
-    await waitFor(() => expect(screen.getByText('Date of birth')).toBeTruthy())
-    await waitFor(() =>
-      expect(screen.getByRole('link', { name: 'How to fix an error in your date of birth' })).toBeTruthy(),
-    )
-    await waitFor(() => expect(screen.getByText('Preferred name')).toBeTruthy())
-    await waitFor(() => expect(screen.getByText('Gender identity')).toBeTruthy())
+    await waitFor(() => expect(screen.getByText(t('personalInformation.preferredName.title'))).toBeTruthy())
+    await waitFor(() => expect(screen.getByText(t('personalInformation.genderIdentity.title'))).toBeTruthy())
   })
 
   describe('when there is no birth date', () => {
@@ -95,7 +94,7 @@ context('PersonalInformationScreen', () => {
           },
         },
       ])
-      await waitFor(() => expect(screen.getByText('This information is not available right now')).toBeTruthy())
+      await waitFor(() => expect(screen.getByText(t('personalInformation.informationNotAvailable'))).toBeTruthy())
     })
   })
 
@@ -122,8 +121,24 @@ context('PersonalInformationScreen', () => {
   describe("when demographics information isn't set", () => {
     it('displays message on sharing gender identity and preferred name', async () => {
       renderWithData()
-      await waitFor(() => expect(screen.getByText('Sharing your gender identity is optional.')).toBeTruthy())
-      await waitFor(() => expect(screen.getByText('Sharing your preferred name is optional.')).toBeTruthy())
+      await waitFor(() =>
+        expect(
+          screen.getByText(
+            t('personalInformation.genericBody', {
+              informationType: t('personalInformation.genderIdentity.title').toLowerCase(),
+            }),
+          ),
+        ).toBeTruthy(),
+      )
+      await waitFor(() =>
+        expect(
+          screen.getByText(
+            t('personalInformation.genericBody', {
+              informationType: t('personalInformation.preferredName.title').toLowerCase(),
+            }),
+          ),
+        ).toBeTruthy(),
+      )
     })
   })
 
@@ -152,7 +167,7 @@ context('PersonalInformationScreen', () => {
         .mockRejectedValue({ networkError: 500 })
 
       renderWithData()
-      await waitFor(() => expect(screen.getByText("The app can't be loaded.")).toBeTruthy())
+      await waitFor(() => expect(screen.getByText(t('errors.networkConnection.header'))).toBeTruthy())
     })
   })
 })

--- a/VAMobile/src/screens/HomeScreen/ProfileScreen/PersonalInformationScreen/PersonalInformationScreen.test.tsx
+++ b/VAMobile/src/screens/HomeScreen/ProfileScreen/PersonalInformationScreen/PersonalInformationScreen.test.tsx
@@ -29,7 +29,7 @@ when(get as jest.Mock)
           tm: 'Transgender Man',
           tf: 'Transgender Woman',
           f: 'Woman',
-          n: t('personalInformation.genderIdentity.preferNotToAnswer'),
+          n: 'Prefer not to answer',
           o: 'A gender not listed here',
         },
       },

--- a/VAMobile/src/screens/HomeScreen/ProfileScreen/PersonalInformationScreen/PreferredNameScreen/PreferredNameScreen.test.tsx
+++ b/VAMobile/src/screens/HomeScreen/ProfileScreen/PersonalInformationScreen/PreferredNameScreen/PreferredNameScreen.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { fireEvent, screen } from '@testing-library/react-native'
+import { t } from 'i18next'
 
 import { context, mockNavProps, render } from 'testUtils'
 
@@ -13,33 +14,33 @@ context('PreferredNameScreen', () => {
   })
 
   it('initializes correctly', () => {
-    expect(screen.getByRole('header', { name: 'Preferred name' })).toBeTruthy()
-    expect(screen.getByText("Share the name you'd like us to use when you come in to VA.")).toBeTruthy()
-    expect(screen.getByText('25 characters maximum')).toBeTruthy()
+    expect(screen.getByRole('header', { name: t('personalInformation.preferredName.title') })).toBeTruthy()
+    expect(screen.getByText(t('personalInformation.preferredNameScreen.body'))).toBeTruthy()
+    expect(screen.getByText(t('personalInformation.preferredName.editHelperText'))).toBeTruthy()
     expect(screen.getByTestId('preferredNameTestID')).toBeTruthy()
-    expect(screen.getByRole('button', { name: 'Save' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: t('save') })).toBeTruthy()
   })
 
   describe('when name has a number in it', () => {
     it('should show error text', () => {
       fireEvent.changeText(screen.getByTestId('preferredNameTestID'), 'Bobby3')
-      fireEvent.press(screen.getByRole('button', { name: 'Save' }))
-      expect(screen.getByText('Enter letters only')).toBeTruthy()
+      fireEvent.press(screen.getByRole('button', { name: t('save') }))
+      expect(screen.getByText(t('personalInformation.preferredName.lettersOnly'))).toBeTruthy()
     })
   })
 
   describe('when name has to many characters', () => {
     it('should show error text', () => {
       fireEvent.changeText(screen.getByTestId('preferredNameTestID'), 'abcdefghijklmnopqrstuvwxyz')
-      fireEvent.press(screen.getByRole('button', { name: 'Save' }))
-      expect(screen.getByText('Enter 25 characters or less for preferred name')).toBeTruthy()
+      fireEvent.press(screen.getByRole('button', { name: t('save') }))
+      expect(screen.getByText(t('personalInformation.preferredName.tooManyCharacters'))).toBeTruthy()
     })
   })
 
   describe('when name ie empty', () => {
     it('should show error text', () => {
-      fireEvent.press(screen.getByRole('button', { name: 'Save' }))
-      expect(screen.getByText('Enter a preferred name')).toBeTruthy()
+      fireEvent.press(screen.getByRole('button', { name: t('save') }))
+      expect(screen.getByText(t('personalInformation.preferredName.fieldEmpty'))).toBeTruthy()
     })
   })
 })


### PR DESCRIPTION
## Description of Change
Update the unit test in #9996 to use 18n
## Screenshots/Video
<!-- Add screenshots or video as needed. Before/after if changes are to be compared by reviewers.
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Toggle: <details><summary></summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>
-->

## Testing
<!-- What testing was done to verify the changes (local/unit)? What testing remains? Note edge cases, or special
situations that could not be tested during development. -->

- [ ] Tested on iOS <!-- simulator is fine -->
- [ ] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
<!-- What should reviewers look for? Copy/paste Acceptance Criteria from ticket -->

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [ ] Tests are included to cover this change (when possible)
- [ ] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [ ] No secrets or API keys are checked in
- [ ] All imports are absolute (no relative imports)
- [ ] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
