### PR TITLE
Fixing the daily accessibility scan for the documentation site

### DIFF
--- a/.github/workflows/documentation_accessibility_checks.yml
+++ b/.github/workflows/documentation_accessibility_checks.yml
@@ -15,17 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Setup node and restore yarn cache
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: 'VAMobile/.nvmrc'
+          cache: 'yarn'
+          cache-dependency-path: 'VAMobile/yarn.lock'
       - name: Clean npm cache
         run: npm cache clean --force
       - name: Install Axe CLI globally
         run: npm install -g @axe-core/cli@latest
-      - name: Update npm 
-        run: npm install -g npm@latest
-      - uses: actions/setup-node@v3
-        with:
-          node-version-file: 'VAMobile/.nvmrc'
-          cache: yarn
-          cache-dependency-path: VAMobile/yarn.lock 
       - name: Install latest version of chromeDriver
         run: npm install -g chromedriver@latest
       - name: Test build

--- a/.github/workflows/documentation_accessibility_checks.yml
+++ b/.github/workflows/documentation_accessibility_checks.yml
@@ -1,9 +1,6 @@
 name: '[Documentation] Accessibility Check'
 
-# Adapted from https://docusaurus.io/docs/deployment
-
 on:
-  pull_request:
   workflow_dispatch:
   # Run on Weekdays at 9:00 AM UTC, 4AM ET, 1:00 AM PT
   schedule:
@@ -27,7 +24,7 @@ jobs:
         run: npm install -g @axe-core/cli@latest
       - name: Install latest version of chromeDriver
         run: npm install -g chromedriver@latest
-      - name: Test build
+      - name: Run build to generate sitemap
         working-directory: VAMobile
         run: |
           yarn install --frozen-lockfile

--- a/.github/workflows/documentation_accessibility_checks.yml
+++ b/.github/workflows/documentation_accessibility_checks.yml
@@ -3,6 +3,7 @@ name: '[Documentation] Accessibility Check'
 # Adapted from https://docusaurus.io/docs/deployment
 
 on:
+  pull_request:
   workflow_dispatch:
   # Run on Weekdays at 9:00 AM UTC, 4AM ET, 1:00 AM PT
   schedule:

--- a/.github/workflows/documentation_accessibility_checks.yml
+++ b/.github/workflows/documentation_accessibility_checks.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           yarn install --frozen-lockfile
           cd documentation
+          npx update-browserslist-db@latest
           yarn install --frozen-lockfile
           yarn build
       - name: Start web server
@@ -77,7 +78,7 @@ jobs:
         env:
           SLACK_API_TOKEN: ${{ secrets.SLACK_API_TOKEN }}
           channel_name: va-mobile-build-alerts
-          message: 'Accessibility issues detected. Please review and fix. Build started by ${{ github.actor }}: (:git: `${{ github.ref_name }}`). See :thread: or <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow run> for results.'
+          message: 'Accessibility issues detected. See :thread: or <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|workflow run> for results.'
         run: |
           curl -X POST \
                -H "Authorization: Bearer $SLACK_API_TOKEN" \


### PR DESCRIPTION
## Description of Change

Fixing the daily accessibility documentation scan workflow. It's been failing on installing npm. The command is run after npm is used, so I don't think it's necessary. 