### PR TITLE
bug/9476-KeyboardNavigation

### DIFF
--- a/VAMobile/src/components/FormWrapper/FormFields/VATextInput.tsx
+++ b/VAMobile/src/components/FormWrapper/FormFields/VATextInput.tsx
@@ -170,7 +170,7 @@ const VATextInput: FC<VATextInputProps> = (props: VATextInputProps) => {
       </Box>
     )
 
-    return <Box>{content}</Box>
+    return <Box focusable>{content}</Box>
   }
 
   return renderTextInput()

--- a/VAMobile/src/utils/hooks/index.tsx
+++ b/VAMobile/src/utils/hooks/index.tsx
@@ -347,6 +347,7 @@ export function useDestructiveActionSheet(): (props: useDestructiveActionSheetPr
         options: newButtons.map((button) => stringToTitleCase(isIOS() ? button.text : button.text + ' ')),
         containerStyle: { backgroundColor: currentTheme.colors.background.contentBox },
         cancelButtonIndex: isIpad() ? undefined : newButtons.length - 1,
+        autoFocus: true,
       },
       (buttonIndex) => {
         if (buttonIndex || buttonIndex === 0) {


### PR DESCRIPTION
## Description of Change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, 
need to know about this PR in order to understand why this PR was created? This could include dependencies 
introduced, changes in behavior, pointers to more detailed documentation. The description should be more 
than a link to an issue.  -->
Fixes some of the physical keyboard issues seen in Android, particularly native alerts not being accessible and not being able to navigate past text inputs.

## Screenshots/Video
<!-- Add screenshots or video as needed. Before/after if changes are to be compared by reviewers.
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Toggle: <details><summary></summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>
-->

### Before
Unable to navigate past the text input fields, which causes the focus to shift to the previous screen.

[Keyboard Navigation Before.webm](https://github.com/user-attachments/assets/8a3486d3-9bdf-4107-97bf-288a116aa3ca)

### After
Able to navigate throughout the entire page without getting stuck.

[Keyboard Navigation After.webm](https://github.com/user-attachments/assets/f0ec4c84-8559-4205-9e3b-8a107f7ba20e)

## Testing
<!-- What testing was done to verify the changes (local/unit)? What testing remains? Note edge cases, or special
situations that could not be tested during development. -->
Tested locally on Android.

- [ ] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
<!-- What should reviewers look for? Copy/paste Acceptance Criteria from ticket -->
Verify physical keyboard navigation on Android doesn't get stuck on text input fields.

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [ ] PR is connected to issue(s)
- [ ] Tests are included to cover this change (when possible)
- [ ] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [ ] No secrets or API keys are checked in
- [ ] All imports are absolute (no relative imports)
- [ ] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
