### PR TITLE
Bug/9461 - iOS - Some assistive tech can't get 'into'/'onto' screens where the only actionable items are initially offscreen

### DIFF
--- a/VAMobile/src/components/Templates/FeatureLandingAndChildTemplate.tsx
+++ b/VAMobile/src/components/Templates/FeatureLandingAndChildTemplate.tsx
@@ -144,7 +144,7 @@ export const ChildTemplate: FC<ChildTemplateProps> = ({
         }}
         {...scrollViewProps}>
         <View accessible accessibilityLabel={titleA11y} onLayout={getTransitionHeaderHeight}>
-          {!screenReaderEnabled ? <TextView {...subtitleProps}>{title}</TextView> : null}
+          {!screenReaderEnabled ? <TextView {...subtitleProps}>{title}</TextView> : <TextView>{'\u200B'}</TextView>}
         </View>
         <WaygateWrapper>{children}</WaygateWrapper>
       </VAScrollView>

--- a/VAMobile/src/components/Templates/FeatureLandingAndChildTemplate.tsx
+++ b/VAMobile/src/components/Templates/FeatureLandingAndChildTemplate.tsx
@@ -143,7 +143,7 @@ export const ChildTemplate: FC<ChildTemplateProps> = ({
           transitionHeader(event.nativeEvent.contentOffset.y)
         }}
         {...scrollViewProps}>
-        <View onLayout={getTransitionHeaderHeight}>
+        <View accessible accessibilityLabel={title} onLayout={getTransitionHeaderHeight}>
           {!screenReaderEnabled ? <TextView {...subtitleProps}>{title}</TextView> : null}
         </View>
         <WaygateWrapper>{children}</WaygateWrapper>

--- a/VAMobile/src/components/Templates/FeatureLandingAndChildTemplate.tsx
+++ b/VAMobile/src/components/Templates/FeatureLandingAndChildTemplate.tsx
@@ -143,7 +143,7 @@ export const ChildTemplate: FC<ChildTemplateProps> = ({
           transitionHeader(event.nativeEvent.contentOffset.y)
         }}
         {...scrollViewProps}>
-        <View accessible accessibilityLabel={title} onLayout={getTransitionHeaderHeight}>
+        <View accessible accessibilityLabel={titleA11y} onLayout={getTransitionHeaderHeight}>
           {!screenReaderEnabled ? <TextView {...subtitleProps}>{title}</TextView> : null}
         </View>
         <WaygateWrapper>{children}</WaygateWrapper>


### PR DESCRIPTION
## Description of Change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, 
need to know about this PR in order to understand why this PR was created? This could include dependencies 
introduced, changes in behavior, pointers to more detailed documentation. The description should be more 
than a link to an issue.  -->

[Ticket](https://github.com/department-of-veterans-affairs/va-mobile-app/issues/9461)

On iOS, Full Keyboard Access requires at least one visible, focusable element to reach off-screen content, unlike Android. Previously, some screens offered no immediate focusable elements, preventing keyboard navigation on iOS.

All affected screens share the same layout component, so I adjusted the accessibility properties in that component (FeatureLandingTemplate). I also tested with LargeFontSize enabled to account for the edge case mentioned in the ticket.

Here's a list of affected screens I found:

- Health Tab > Messages > Inbox > Select a Message (Some messages have the issue)
- Health Tab > Messages > Folders > Sent >  Select a Message (Some messages have the issue)
- Benefits > VA letters and documents > Review Letters > Items 1, 2, 4 & 6 are affected

## Screenshots/Video
<!-- Add screenshots or video as needed. Before/after if changes are to be compared by reviewers.
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Toggle: <details><summary></summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>
-->

Here's a video showing how Full Keyboard Access navigation looks with the new changes.

https://github.com/user-attachments/assets/a93f5629-0879-4a74-aff2-42d228edfd39

## Testing
<!-- What testing was done to verify the changes (local/unit)? What testing remains? Note edge cases, or special
situations that could not be tested during development. -->

- [x] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
<!-- What should reviewers look for? Copy/paste Acceptance Criteria from ticket -->

Should be able to navigate to actionable content with keyboard navigation only, no matter if it's initially onscreen or not

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [ ] PR is connected to issue(s)
- [ ] Tests are included to cover this change (when possible)
- [ ] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [ ] No secrets or API keys are checked in
- [ ] All imports are absolute (no relative imports)
- [ ] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
