### PR TITLE
bug/10241 Android Text Collision with claims history

### DIFF
--- a/VAMobile/src/components/Templates/HeaderBanner.tsx
+++ b/VAMobile/src/components/Templates/HeaderBanner.tsx
@@ -84,7 +84,7 @@ const HeaderBanner: FC<HeaderBannerProps> = ({
   useFocusEffect(focus === 'Title' ? setFocusTitle : setFocus)
   const screenReaderEnabled = useIsScreenReaderEnabled()
 
-  const TEXT_CONSTRAINT_THRESHOLD = 30
+  const TEXT_CONSTRAINT_THRESHOLD = 26
 
   const transition = title?.type === 'Transition'
 


### PR DESCRIPTION
## Description of Change
Pretty simple change, changes the text wrap threshhold for the header banner so that it wraps a few lengths sooner. 

for https://github.com/department-of-veterans-affairs/va-mobile-app/issues/10241

## Screenshots/Video
Before: 
![image](https://github.com/user-attachments/assets/bbee5bfd-b4b9-40e6-8989-ff3733d728a3)
After: 
![image](https://github.com/user-attachments/assets/522e0a17-36b6-4b9d-9261-351176953216)


## Testing

- [ ] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android 

## Reviewer Validations
<!-- What should reviewers look for? Copy/paste Acceptance Criteria from ticket -->

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
