### PR TITLE
Specifying XCode Version in ios e2e Action

### DIFF
--- a/.github/workflows/e2e_ios.yml
+++ b/.github/workflows/e2e_ios.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: 15.2
 
       - name: Setup node and restore yarn cache
         uses: actions/setup-node@v3


### PR DESCRIPTION
## Description of Change
Towards the beginning of the year the ios e2e build started to fail. There were some changes to the "mac-14" runner from github around that time, so my suspicion is that something broke in that chain. I can't say for certain *_which_* dependency was a problem exactly as the ios bundle process spits out an immense amount of logging to the point where github literally fails to allow me to download the full raw log to parse through.

With all of that being said, I noticed that our QA builds were building just fine so after some comparative analysis, the only conclusion I could draw was the difference in xcode version being specified in the process. After ye olde college try it looks like this allows the e2e build to complete successfully and proceed running the suite.

**Sidenote:** I also attempted a run with mac-15 runners as they offer a slightly different pre-installed dependency list, while the build completed the tests themselves couldn't run. My suspicion there is something is different with the specific emulator we're grabbing to with detox. Something we could experiment around with in the future if we wanted to update to mac 15.  

resolves: https://github.com/department-of-veterans-affairs/va-mobile-feature-support/issues/193

## Testing/Proof
- Latest Failing ios e2e action: https://github.com/department-of-veterans-affairs/va-mobile-app/actions/runs/12900962608 
  - You can go into any of the individual tests to see that it's failing on the step to bundle the app
- Mac 15 Attempt: https://github.com/department-of-veterans-affairs/va-mobile-app/actions/runs/12835403737/job/35794827234
  - You can see in this one it failing just past the bundling of the app when it attempts to run the suite
- Proposed Change (Specifying xcode version): https://github.com/department-of-veterans-affairs/va-mobile-app/actions/runs/12910102521
  - While this action *does* fail, it's in one of the individual tests which I will be exploring as my next up task. The job is doing what it's supposed to do

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [x] Tests are included to cover this change (when possible)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked in
- [x] All imports are absolute (no relative imports)
- [x] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
