### PR TITLE
bug/9612-PushNotificationDeepLinkPersistsThroughLogout

### DIFF
--- a/VAMobile/src/components/NotificationManager/NotificationManager.tsx
+++ b/VAMobile/src/components/NotificationManager/NotificationManager.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, FC, SetStateAction, createContext, useContext, useEffect, useState } from 'react'
+import React, { Dispatch, FC, SetStateAction, createContext, useContext, useEffect, useRef, useState } from 'react'
 import { Linking, View } from 'react-native'
 import { NotificationBackgroundFetchResult, Notifications } from 'react-native-notifications'
 import { useSelector } from 'react-redux'
@@ -31,6 +31,7 @@ const NotificationContext = createContext<NotificationContextType>({
  */
 const NotificationManager: FC = ({ children }) => {
   const { loggedIn, firstTimeLogin, requestNotifications } = useSelector<RootState, AuthState>((state) => state.auth)
+  const loggedInRef = useRef(loggedIn)
   const { data: personalInformation } = usePersonalInformation({ enabled: loggedIn })
   const { mutate: registerDevice } = useRegisterDevice()
   const [tappedForegroundNotification, setTappedForegroundNotification] = useState(false)
@@ -38,6 +39,8 @@ const NotificationManager: FC = ({ children }) => {
   const [eventsRegistered, setEventsRegistered] = useState(false)
 
   useEffect(() => {
+    loggedInRef.current = loggedIn
+
     const register = () => {
       const registeredNotifications = Notifications.events().registerRemoteNotificationsRegistered((event) => {
         const registerParams = {
@@ -88,7 +91,7 @@ const NotificationManager: FC = ({ children }) => {
       // Open deep link from the notification when present. If the user is
       // not logged in, store the link so it can be opened after authentication.
       if (notification.payload.url) {
-        if (loggedIn) {
+        if (loggedInRef.current) {
           Linking.openURL(notification.payload.url)
         } else {
           setInitialUrl(notification.payload.url)


### PR DESCRIPTION
## Description of Change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, 
need to know about this PR in order to understand why this PR was created? This could include dependencies 
introduced, changes in behavior, pointers to more detailed documentation. The description should be more 
than a link to an issue.  -->
This issue was caused by faulty logic in the [NotificationManager](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/components/NotificationManager/NotificationManager.tsx) module. The `registerNotificationOpened` event is called one time and utilizes the state of `loggedIn`, which is always `false` when the app starts up. After a user logs in the state of `loggedIn` gets set to `true`, but this event handler is still working with its original value as it is never made aware of the change. Therefore when a notification gets opened, `loggedIn` is always `false` and the code ends up calling `setInitialUrl` instead of `Linking.openUrl`. To fix this, `loggedInRef` was created using the `useRef` hook so the current state of `loggedIn` could be picked up correctly.

## Screenshots/Video
<!-- Add screenshots or video as needed. Before/after if changes are to be compared by reviewers.
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Toggle: <details><summary></summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>
-->

## Testing
<!-- What testing was done to verify the changes (local/unit)? What testing remains? Note edge cases, or special
situations that could not be tested during development. -->

- [ ] Tested on iOS <!-- simulator is fine -->
- [x] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
<!-- What should reviewers look for? Copy/paste Acceptance Criteria from ticket -->
Here is the sequence that reproduces the issue:
1. Log into the app with any staging user.
2. Send a secure message push notification to the app.
3. Open the push notification and the deep link takes you to a secure message.
4. Without closing the app, log into another staging account.
5. Before the fix, the new user would pick up the notification after logging in and be deep linked to a message that does not belong to them. After the fix, the new user does not get deep linked to a message.

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [ ] PR is connected to issue(s)
- [ ] Tests are included to cover this change (when possible)
- [ ] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [ ] No secrets or API keys are checked in
- [ ] All imports are absolute (no relative imports)
- [ ] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
