### PR TITLE
Appointments Expanded Date Fix

### DIFF
--- a/VAMobile/e2e/tests/AppointmentsExpanded.e2e.ts
+++ b/VAMobile/e2e/tests/AppointmentsExpanded.e2e.ts
@@ -522,7 +522,7 @@ export async function apppointmentVerification(pastAppointment = false) {
       } else {
         await element(by.text(CommonE2eIdConstants.DATE_RANGE_INITIAL_TEXT)).atIndex(0).tap()
       }
-      await element(by.text('All of 2023')).tap()
+      await element(by.text('All of ${new Date().getFullYear() - 1}')).tap()
       await element(by.text('Done')).tap()
     }
     await scrollToThenTap('Sami Alsahhar - Onsite - Pending', pastAppointmentString)

--- a/VAMobile/e2e/tests/AppointmentsExpanded.e2e.ts
+++ b/VAMobile/e2e/tests/AppointmentsExpanded.e2e.ts
@@ -522,7 +522,7 @@ export async function apppointmentVerification(pastAppointment = false) {
       } else {
         await element(by.text(CommonE2eIdConstants.DATE_RANGE_INITIAL_TEXT)).atIndex(0).tap()
       }
-      await element(by.text('All of ${new Date().getFullYear() - 1}')).tap()
+      await element(by.text(`All of ${new Date().getFullYear() - 1}`)).tap()
       await element(by.text('Done')).tap()
     }
     await scrollToThenTap('Sami Alsahhar - Onsite - Pending', pastAppointmentString)


### PR DESCRIPTION
## Description of Change
Appointments expanded runs only on iOS and has been failing. Turns out there is a hard coded date in there which triggers the rest of the tests past it to fail. This fixes that. 

Random Notes:
- I tried making this test suite run on Android for a while and ran into a lot of strange errors where an element would be on the screen but detox would say it's not there. I'm assuming thats why this one is labeled `:ios:` 

## Links
- [failing run](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/runs/13668269988/job/38213685196)
- [passing run](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/runs/13682252926)
