### PR TITLE
Enable all users to view veteran status card

### DIFF
--- a/VAMobile/src/components/Nametag/Nametag.tsx
+++ b/VAMobile/src/components/Nametag/Nametag.tsx
@@ -33,7 +33,7 @@ export const Nametag = () => {
     }
   }, [personalInfo])
 
-  const accLabel = branch !== '' ? `${branch} ${t('veteranStatus.proofOf')}` : branch
+  const accLabel = branch !== '' ? `${branch} ${t('veteranStatus.proofOf')}` : undefined
 
   const pressableProps: PressableProps = {
     onPress: () => navigateTo('VeteranStatus'),

--- a/VAMobile/src/components/Nametag/Nametag.tsx
+++ b/VAMobile/src/components/Nametag/Nametag.tsx
@@ -33,20 +33,11 @@ export const Nametag = () => {
     }
   }, [personalInfo])
 
-  const showVeteranStatus = !!serviceHistory?.serviceHistory?.find(
-    (service) => service.honorableServiceIndicator === 'Y',
-  )
-
-  let accLabel
-  if (!accessToMilitaryInfo) {
-    accLabel = undefined
-  } else {
-    accLabel = showVeteranStatus ? `${branch} ${t('veteranStatus.proofOf')}` : branch
-  }
+  const accLabel = branch !== '' ? `${branch} ${t('veteranStatus.proofOf')}` : branch
 
   const pressableProps: PressableProps = {
-    onPress: () => (accessToMilitaryInfo && showVeteranStatus ? navigateTo('VeteranStatus') : undefined),
-    accessibilityRole: accessToMilitaryInfo && showVeteranStatus ? 'link' : 'text',
+    onPress: () => navigateTo('VeteranStatus'),
+    accessibilityRole: 'link',
     accessibilityLabel: accLabel,
     style: ({ pressed }) => [
       {
@@ -54,7 +45,7 @@ export const Nametag = () => {
           ? theme.colors.background.listActive
           : (theme.colors.background.veteranStatusHome as BackgroundVariant),
         justifyContent: 'center',
-        minHeight: accessToMilitaryInfo ? 82 : undefined,
+        minHeight: 82,
         paddingLeft: theme.dimensions.buttonPadding,
         borderRadius: 8,
         marginBottom: theme.dimensions.standardMarginBetween,
@@ -85,25 +76,21 @@ export const Nametag = () => {
               <TextView variant={'VeteranStatusBranch'} pb={4}>
                 {branch}
               </TextView>
-              {showVeteranStatus && (
-                <Box flexDirection={'row'} alignItems={'center'}>
-                  <TextView variant={'VeteranStatusProof'} mr={theme.dimensions.textIconMargin}>
-                    {t('veteranStatus.proofOf')}
-                  </TextView>
-                </Box>
-              )}
-            </Box>
-            {showVeteranStatus && (
-              <Box ml={theme.dimensions.listItemDecoratorMarginLeft}>
-                <Icon
-                  name={'ChevronRight'}
-                  fill={theme.colors.icon.linkRow}
-                  width={theme.dimensions.chevronListItemWidth}
-                  height={theme.dimensions.chevronListItemHeight}
-                  preventScaling={true}
-                />
+              <Box flexDirection={'row'} alignItems={'center'}>
+                <TextView variant={'VeteranStatusProof'} mr={theme.dimensions.textIconMargin}>
+                  {t('veteranStatus.proofOf')}
+                </TextView>
               </Box>
-            )}
+            </Box>
+            <Box ml={theme.dimensions.listItemDecoratorMarginLeft}>
+              <Icon
+                name={'ChevronRight'}
+                fill={theme.colors.icon.linkRow}
+                width={theme.dimensions.chevronListItemWidth}
+                height={theme.dimensions.chevronListItemHeight}
+                preventScaling={true}
+              />
+            </Box>
           </Box>
         </Pressable>
       )}


### PR DESCRIPTION
## Description of Change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, 
need to know about this PR in order to understand why this PR was created? This could include dependencies 
introduced, changes in behavior, pointers to more detailed documentation. The description should be more 
than a link to an issue.  -->

Updated the `Nametag` component to remove its reliance on honorable-discharge checks before showing the `VeteranStatusScreen`. We now always allow users to tap through to the Veteran Status screen, where Title 38 eligibility is handled. Keep in mind, the user still has to have a service history in order to see the `Nametag` component.

[Original ticket](https://github.com/department-of-veterans-affairs/va-mobile-feature-support/issues/260)

## Screenshots/Video
<!-- Add screenshots or video as needed. Before/after if changes are to be compared by reviewers.
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Toggle: <details><summary></summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details>
-->

Tested on user 32 (Tamara Ellis).

vets.gov.user+32@gmail.com
134SsNrLgPv5


https://github.com/user-attachments/assets/e9104eb9-529f-4cb7-9253-0989ec87e2c7



## Testing
<!-- What testing was done to verify the changes (local/unit)? What testing remains? Note edge cases, or special
situations that could not be tested during development. -->

Account with service history & title 38 confirmed:
[vets.gov](http://vets.gov/).[user+16@gmail.com](mailto:user+16@gmail.com)
296SsNrLgPv5

[Other test accounts for Veteran Status (YMMV)](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/blob/master/Administrative/vagov-users/staging-test-accounts-Veteran-Status.md)

**Note:** Because most staging accounts lack any service history, you won’t see the Nametag (and thus the VeteranStatusScreen) by default—even if a user is Title 38 eligible. If you temporarily mock service history data in the Nametag (ensuring branch isn’t undefined), you’ll be able to trigger the VeteranStatusScreen and view the relevant messages for testing.

- [X] Tested on iOS <!-- simulator is fine -->
- [ ] Tested on Android <!-- simulator is fine -->

## Reviewer Validations
<!-- What should reviewers look for? Copy/paste Acceptance Criteria from ticket -->

## PR Checklist
<!-- Engineer: make sure all these items are checked off before requesting a review -->
  **Reviewer:** Confirm the items below as you review

- [x] PR is connected to issue(s)
- [ ] Tests are included to cover this change (when possible)
- [ ] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [ ] No secrets or API keys are checked in
- [ ] All imports are absolute (no relative imports)
- [ ] New functions and Redux work have proper TSDoc annotations

## For QA

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
