### PR TITLE
Add Jest Reporter for slow tests

### DIFF
--- a/VAMobile/jest.config.js
+++ b/VAMobile/jest.config.js
@@ -15,6 +15,14 @@ module.exports = {
         addFileAttribute: 'true',
       },
     ],
+    [
+      'jest-slow-test-reporter',
+      {
+        numTests: 5,
+        warnOnSlowerThan: 1000,
+        color: true,
+      },
+    ],
   ],
   transform: {
     '^.+\\.tsx?$': [

--- a/VAMobile/package.json
+++ b/VAMobile/package.json
@@ -136,6 +136,7 @@
     "jest-environment-jsdom": "29.7.0",
     "jest-image-snapshot": "^6.4.0",
     "jest-junit": "^16.0.0",
+    "jest-slow-test-reporter": "^1.0.0",
     "jest-when": "^3.7.0",
     "lint-staged": "^15.2.9",
     "metro-react-native-babel-preset": "^0.77.0",

--- a/VAMobile/yarn.lock
+++ b/VAMobile/yarn.lock
@@ -7900,6 +7900,11 @@ jest-runtime@^29.7.0:
     slash "^3.0.0"
     strip-bom "^4.0.0"
 
+jest-slow-test-reporter@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/jest-slow-test-reporter/-/jest-slow-test-reporter-1.0.0.tgz#cb8b4fa3212c1bf9fd3794c79faf0c863807d59e"
+  integrity sha512-5FG8hlaO7Wdgdo6oQxGiFAKwd1HW51+8/KmQJgUV3bsW3cCXx9TukaoGnHhBl+hwLkCYENynWL1PQnG8DwOV6w==
+
 jest-snapshot@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-29.7.0.tgz#c2c574c3f51865da1bb329036778a69bf88a6be5"


### PR DESCRIPTION
## Description of Change

Adding a new reporter to help us identify the top 5 tests that take more than 1 second to complete.

## Output

```
Top 5 slowest examples (23.967 seconds, 10.1% of total time):
  screens HealthScreen Allergies AllergyDetails AllergyDetailsScreen initializes correctly for default allergy
    6.104 seconds [...]AllergyDetailsScreen.test.tsx
  screens HealthScreen Pharmacy PrescriptionDetails PrescriptionDetails Go to My VA Health button when status is RefillStatusConstants.TRANSFERRED should display FooterButton
    5.577 seconds [...]PrescriptionDetails.test.tsx
  screens BenefitsScreen Letters LettersListScreen should render correctly
    4.944 seconds [...]LettersListScreen.test.tsx
  screens HealthScreen SecureMessaging EditDraft EditDraft when no recipients are returned should display an AlertBox and on click of Go to inbox it should navigate
    3.935 seconds [...]/EditDraft.test.tsx
  screens HealthScreen Allergies AllergyDetails AllergyDetailsScreen initializes correctly for allergy with multiple categories
    3.407 seconds [...]/AllergyDetailsScreen.test.tsx
```