### PR TITLE
542 - Update system error to yellow warning alert

### DIFF
--- a/VAMobile/src/screens/HomeScreen/VeteranStatusScreen/VeteranStatusScreen.tsx
+++ b/VAMobile/src/screens/HomeScreen/VeteranStatusScreen/VeteranStatusScreen.tsx
@@ -28,6 +28,7 @@ import {
 import { Events } from 'constants/analytics'
 import { NAMESPACE } from 'constants/namespaces'
 import { HomeStackParamList } from 'screens/HomeScreen/HomeStackScreens'
+import VeteranStatusCard from 'screens/HomeScreen/VeteranStatusScreen/VeteranStatusCard/VeteranStatusCard'
 import { a11yLabelID, a11yLabelVA } from 'utils/a11yLabel'
 import { logAnalyticsEvent } from 'utils/analytics'
 import { isValidDisabilityRating } from 'utils/claims'
@@ -35,8 +36,6 @@ import { displayedTextPhoneNumber } from 'utils/formattingUtils'
 import { useBeforeNavBackListener, useOrientation, useTheme } from 'utils/hooks'
 import { useReviewEvent } from 'utils/inAppReviews'
 import { featureEnabled } from 'utils/remoteConfig'
-
-import VeteranStatusCard from './VeteranStatusCard/VeteranStatusCard'
 
 // import PhotoUpload from 'components/PhotoUpload'
 
@@ -146,7 +145,7 @@ function VeteranStatusScreen({ navigation }: VeteranStatusScreenProps) {
     if (isError || notConfirmedReason === 'ERROR') {
       return (
         <AlertWithHaptics
-          variant="error"
+          variant="warning"
           header={t('errors.somethingWentWrong')}
           headerA11yLabel={a11yLabelVA(t('errors.somethingWentWrong'))}
           description={t('veteranStatus.error.generic')}


### PR DESCRIPTION
## Description of Change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, 
need to know about this PR in order to understand why this PR was created? This could include dependencies 
introduced, changes in behavior, pointers to more detailed documentation. The description should be more 
than a link to an issue. -->

The VA website had some [UX adjustments](https://github.com/department-of-veterans-affairs/vets-website/pull/37465) made, one of them included the VSC error warning. Based on feedback we needed to update the "Something went wrong" alert from an error alert to a warning alert. This PR is for updating the mobile app with the same change to keep things consistent between the two platforms.

Also, updated the VeteranStatusCard import due to new linter pattern flagging it.

## Link to Issue
<!--Link to an issue by posting the issue link here. Your pull request is required to be linked to an issue in order for the pull request to Activate.-->

[542](https://github.com/department-of-veterans-affairs/va-mobile-feature-support/issues/542)

## Screenshots
<!-- Add screenshots or video as needed. Before/after if changes are to be compared by reviewers.
Before/after: <img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" />
Toggle: <details><summary></summary><img src="" width="49%" />&nbsp;&nbsp;<img src="" width="49%" /></details> -->

|         | Before | After |
| ------- | ------ | ----- |
| **"Something went wrong"** alert change | <img width="683" alt="intro-before" src="https://github.com/user-attachments/assets/c8411014-0f72-4c80-aba8-1d90edba843a" /> | <img width="683" alt="intro-after" src="https://github.com/user-attachments/assets/b4601e04-0e56-44a0-b159-a5bd947ee692" />

## Testing Requirements
<!-- What testing was done to verify the changes (local/unit)? What testing remains? Note edge cases, or special
situations that could not be tested during development. -->

- Test with user 41
- Navigate to VSC on HomeScreen
- Wait for "Something went wrong" alert to show

Acceptance Criteria
<!-- AC should be written as should be a pass/fail statements and should include steps to carry out task if needed. -->

- [x] "Something went wrong" alert in the VSC should be yellow now instead of red

Test User(s)
<!-- What test users should be used to test test this feature? Please specify what each test user should test. -->

- [x] Test User 41

## Checklist for PR Submitter
<!-- PR Submitter should make sure all of these items are checked off before requesting a review -->
  **PR Reviewer:** Confirm the items below as you review

### Administrative and documentation

- [x] PR is connected to issue(s)
- [x] Acceptance criteria is added on this PR or referenced from the attached issue

### Code testing

- [ ] Unit tests have been created or updated to cover this change
- [ ] End to end (Detox) tests have been created or updated to cover this change

### Code implementation

- [x] All imports are absolute (no relative imports)
- [x] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [x] No secrets or API keys are checked present in the code

## Checklist for QA
<!-- This checklist is for the QA to complete. -->
  **QA Engineer:** Check off the items below as you test

- [x] Tested on iOS
- [x] Tested on Android

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
