### PR TITLE
11317 Checkbox error state showing icon

### DIFF
--- a/VAMobile/src/components/FormWrapper/FormFields/VASelector.tsx
+++ b/VAMobile/src/components/FormWrapper/FormFields/VASelector.tsx
@@ -124,7 +124,7 @@ const VASelector: FC<VASelectorProps> = ({
       }
       return (
         // eslint-disable-next-line react-native-a11y/has-accessibility-hint
-        <VAIcon {...errorIconProps} testID="CheckBoxError" accessibilityLabel="CheckBoxError" />
+        <VAIcon {...errorIconProps} testID="Error" accessibilityLabel="CheckBoxError" />
       )
     }
 

--- a/VAMobile/src/components/FormWrapper/FormFields/VASelector.tsx
+++ b/VAMobile/src/components/FormWrapper/FormFields/VASelector.tsx
@@ -5,13 +5,12 @@ import { TouchableWithoutFeedback } from 'react-native'
 import { Icon, IconProps } from '@department-of-veterans-affairs/mobile-component-library'
 import { colors } from '@department-of-veterans-affairs/mobile-tokens'
 
+import { Box, BoxProps, TextView, VAIcon, VAIconProps } from 'components'
+import { renderInputError } from 'components/FormWrapper/FormFields/formFieldUtils'
 import { VAIconColors, VATextColors } from 'styles/theme'
 import { a11yHintProp } from 'utils/accessibility'
 import { getTranslation } from 'utils/formattingUtils'
 import { useTheme } from 'utils/hooks'
-
-import { Box, BoxProps, TextView } from '../../index'
-import { renderInputError } from './formFieldUtils'
 
 export enum SelectorType {
   Checkbox = 'Checkbox',
@@ -116,11 +115,16 @@ const VASelector: FC<VASelectorProps> = ({
     }
 
     if (!!error && selectorType === SelectorType.Checkbox) {
+      const errorIconProps: VAIconProps = {
+        name: 'CheckBoxError',
+        stroke: theme.colors.icon.error,
+        width: iconWidth,
+        height: 22,
+        fill: 'checkboxDisabledContrast',
+      }
       return (
-        <Icon
-          {...getIconsProps('Error', theme.colors.icon.error, theme.colors.icon.checkboxDisabledContrast)}
-          testID="Error"
-        />
+        // eslint-disable-next-line react-native-a11y/has-accessibility-hint
+        <VAIcon {...errorIconProps} testID="CheckBoxError" accessibilityLabel="CheckBoxError" />
       )
     }
 


### PR DESCRIPTION
## Description of Change
Reverted a change from January to the checkbox component that caused it to show an error icon instead of the checkbox as an error state. This affects anywhere we use the checkbox with a form wrapper, including claims, upload file, and upload photo

## Link to Issue
closes #11317

## Screenshots/Video
Previous:
<img width="313" height="284" alt="image" src="https://github.com/user-attachments/assets/85e745ac-fbc0-4034-b585-6aac3182b135" />

After update:
<img width="394" height="364" alt="Screenshot 2025-07-18 at 9 14 30 AM" src="https://github.com/user-attachments/assets/332d1393-b9c2-4f08-b368-1542d57d6a42" />

<img width="390" height="357" alt="Screenshot 2025-07-18 at 9 30 25 AM" src="https://github.com/user-attachments/assets/48ca4e33-8bd2-4180-944e-6bf0d607448c" />

## Testing Requirements
<!-- What testing was done to verify the changes (local/unit)? What testing remains? Note edge cases, or special
situations that could not be tested during development. -->


Test User(s)
demo mode

## Checklist for PR Submitter
<!-- PR Submitter should make sure all of these items are checked off before requesting a review -->
  **PR Reviewer:** Confirm the items below as you review

### Administrative and documentation

- [ ] PR is connected to issue(s)
- [ ] Acceptance criteria is added on this PR or referenced from the attached issue

### Code testing

- [ ] Unit tests have been created or updated to cover this change
- [ ] End to end (Detox) tests have been created or updated to cover this change

### Code implementation

- [ ] All imports are absolute (no relative imports)
- [ ] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [ ] No secrets or API keys are checked present in the code

### New features

- [ ] Code is attached to a feature flag, or reason is given for no feature flag
- [ ] Design and UX has been approved by the code mobile team (documented on the PR or attached issue)

## Checklist for QA
<!-- This checklist is for the QA to complete. -->
  **QA Engineer:** Check off the items below as you test

- [x] Tested on iOS
- [x] Tested on Android

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)
