### PR TITLE
Update mac runners to 14

### DIFF
--- a/.github/workflows/build_ios.yml
+++ b/.github/workflows/build_ios.yml
@@ -56,7 +56,7 @@ env:
 
 jobs:
   build_ios:
-    runs-on: macos-latest-xlarge
+    runs-on: macos-14-large
     env:
       # App Store Connect Issuer ID
       APPSTORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.APPSTORE_CONNECT_API_KEY_ISSUER_ID }}

--- a/.github/workflows/e2e_ios.yml
+++ b/.github/workflows/e2e_ios.yml
@@ -134,7 +134,7 @@ jobs:
 
   matrix-e2e-ios:
     if: (!cancelled()) && needs.output_detox_tests_to_run.outputs.output1 != ''
-    runs-on: macos-latest-large
+    runs-on: macos-14-large
     needs: [start_slack_thread, output_detox_tests_to_run]
     env:
       # Path to write secret key to. Also used by fastlane


### PR DESCRIPTION
## Description of Change

Rolling the mac running for detox and normal build back to 14

E2E ios build passing: https://github.com/department-of-veterans-affairs/va-mobile-app/actions/runs/17163645913/job/48698813636

OnDemand build passing: https://github.com/department-of-veterans-affairs/va-mobile-app/actions/runs/17163877308/job/48699519064