### PR TITLE
Adding line break into slack alert for the release issue

### DIFF
--- a/.github/workflows/release_branch_issue.yml
+++ b/.github/workflows/release_branch_issue.yml
@@ -148,7 +148,7 @@ jobs:
           - *Release Manager Approval Due:* ${{ needs.release_ticket.outputs.vaDueDate }}\n\
           - *Tickets Tagged Appropriately:* ${{ needs.release_ticket.outputs.qaDueDate }}\n\n\
           *Contacts:*\n\
-            - *VA PO for awareness:* CC: <@${SLACK_rtwell}>
+            - *VA PO for awareness:* CC: <@${SLACK_rtwell}>\n\
             - *Release coordination:* <@${SLACK_becca}>",
             "thread_ts": "${{ needs.start_slack_thread.outputs.thread_ts }}",
             "unfurl_links": false,


### PR DESCRIPTION
## Description of Change

The Slack alert for release coordination has been missing a line break. [Example](https://dsva.slack.com/archives/C018V2JCWRJ/p1758694371359639?thread_ts=1758694367.063499&cid=C018V2JCWRJ).