### PR TITLE
Chore/121006 bmt2 account for appeal issues with null descriptions

### DIFF
--- a/VAMobile/e2e/tests/Appeals.e2e.ts
+++ b/VAMobile/e2e/tests/Appeals.e2e.ts
@@ -65,6 +65,11 @@ describe('Appeals', () => {
     await expect(element(by.text(AppealsIdConstants.APPEAL_SUBMITTED_TEXT))).toExist()
     await expect(element(by.text('Currently on appeal'))).toExist()
     await expect(element(by.text('Service connection, ureteral stricture'))).toExist()
+    await expect(element(by.text('Service connection, neck strain'))).toExist()
+    // Test for issues with null descriptions
+    // There may be multiple instances of both texts, so use .atIndex(0) for both
+    await expect(element(by.text("We're unable to show 1 issue on appeal")).atIndex(0)).toExist()
+    await expect(element(by.text("We're unable to show 2 issues on appeal")).atIndex(0)).toExist()
   })
 
   it('verify review past events information', async () => {

--- a/VAMobile/src/api/types/ClaimsAndAppealsData.ts
+++ b/VAMobile/src/api/types/ClaimsAndAppealsData.ts
@@ -364,7 +364,7 @@ export const AppealIssueLastAction: {
 
 export type AppealIssue = {
   active: boolean
-  description: string
+  description: string | null
   diagnosticCode: string | null
   lastAction: AppealIssueLastActionTypes
   date: string | null
@@ -404,6 +404,18 @@ export const AppealTypesConstants: {
   higherLevelReview: 'higherLevelReview',
   supplementalClaim: 'supplementalClaim',
   legacyAppeal: 'legacyAppeal',
+  appeal: 'appeal',
+}
+
+export const AppealTypesDisplayNames: {
+  higherLevelReview: 'Higher-Level Review'
+  supplementalClaim: 'Supplemental Claim'
+  legacyAppeal: 'appeal'
+  appeal: 'appeal'
+} = {
+  higherLevelReview: 'Higher-Level Review',
+  supplementalClaim: 'Supplemental Claim',
+  legacyAppeal: 'appeal',
   appeal: 'appeal',
 }
 

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/AppealDetailsScreen/AppealDetailsScreen.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/AppealDetailsScreen/AppealDetailsScreen.tsx
@@ -6,7 +6,13 @@ import { StackScreenProps } from '@react-navigation/stack/lib/typescript/src/typ
 import { SegmentedControl } from '@department-of-veterans-affairs/mobile-component-library'
 
 import { useAppeal } from 'api/claimsAndAppeals'
-import { AppealAttributesData, AppealData, AppealEventTypesConstants, AppealTypesConstants } from 'api/types'
+import {
+  AppealAttributesData,
+  AppealData,
+  AppealEventTypesConstants,
+  AppealTypes,
+  AppealTypesConstants,
+} from 'api/types'
 import { Box, ErrorComponent, FeatureLandingTemplate, LoadingComponent, TextView } from 'components'
 import { NAMESPACE } from 'constants/namespaces'
 import { BenefitsStackParamList } from 'screens/BenefitsScreen/BenefitsStackScreens'
@@ -135,7 +141,9 @@ function AppealDetailsScreen({ navigation, route }: AppealDetailsScreenProps) {
                 programArea={programArea}
               />
             )}
-            {appeal && selectedTab === 1 && <AppealIssues appealType={type} issues={issues} />}
+            {appeal && selectedTab === 1 && (
+              <AppealIssues appealType={appeal.attributes.type as AppealTypes} issues={issues} />
+            )}
           </Box>
           <NeedHelpData appealId={appealID} />
         </Box>

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/AppealDetailsScreen/AppealDetailsScreen.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/AppealDetailsScreen/AppealDetailsScreen.tsx
@@ -10,15 +10,14 @@ import { AppealAttributesData, AppealData, AppealEventTypesConstants, AppealType
 import { Box, ErrorComponent, FeatureLandingTemplate, LoadingComponent, TextView } from 'components'
 import { NAMESPACE } from 'constants/namespaces'
 import { BenefitsStackParamList } from 'screens/BenefitsScreen/BenefitsStackScreens'
+import AppealIssues from 'screens/BenefitsScreen/ClaimsScreen/AppealDetailsScreen/AppealIssues/AppealIssues'
+import AppealStatus from 'screens/BenefitsScreen/ClaimsScreen/AppealDetailsScreen/AppealStatus/AppealStatus'
+import NeedHelpData from 'screens/BenefitsScreen/ClaimsScreen/NeedHelpData/NeedHelpData'
 import { ScreenIDTypesConstants } from 'store/api/types/Screens'
 import { formatDateMMMMDDYYYY, getFormattedTimeForTimeZone, getTranslation } from 'utils/formattingUtils'
 import { useTheme } from 'utils/hooks'
 import { useReviewEvent } from 'utils/inAppReviews'
 import { screenContentAllowed } from 'utils/waygateConfig'
-
-import NeedHelpData from '../NeedHelpData/NeedHelpData'
-import AppealIssues from './AppealIssues/AppealIssues'
-import AppealStatus from './AppealStatus/AppealStatus'
 
 type AppealDetailsScreenProps = StackScreenProps<BenefitsStackParamList, 'AppealDetailsScreen'>
 
@@ -136,7 +135,7 @@ function AppealDetailsScreen({ navigation, route }: AppealDetailsScreenProps) {
                 programArea={programArea}
               />
             )}
-            {appeal && selectedTab === 1 && <AppealIssues issues={issues} />}
+            {appeal && selectedTab === 1 && <AppealIssues appealType={type} issues={issues} />}
           </Box>
           <NeedHelpData appealId={appealID} />
         </Box>

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/AppealDetailsScreen/AppealIssues/AppealIssues.test.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/AppealDetailsScreen/AppealIssues/AppealIssues.test.tsx
@@ -4,9 +4,8 @@ import { screen } from '@testing-library/react-native'
 import { t } from 'i18next'
 
 import { AppealIssue } from 'api/types'
+import AppealIssues from 'screens/BenefitsScreen/ClaimsScreen/AppealDetailsScreen/AppealIssues/AppealIssues'
 import { context, mockNavProps, render } from 'testUtils'
-
-import AppealIssues from './AppealIssues'
 
 context('AppealIssues', () => {
   beforeEach(() => {
@@ -50,7 +49,7 @@ context('AppealIssues', () => {
         active: true,
         description: 'Service connection for tinnitus is denied',
         diagnosticCode: null,
-        lastAction: 'denied',
+        lastAction: 'withdrawn',
         date: null,
       },
       {
@@ -60,8 +59,62 @@ context('AppealIssues', () => {
         lastAction: 'withdrawn',
         date: null,
       },
+      // Issues with null descriptions
+      {
+        active: true,
+        description: null,
+        diagnosticCode: null,
+        lastAction: null,
+        date: null,
+      },
+      {
+        active: true,
+        description: null,
+        diagnosticCode: null,
+        lastAction: null,
+        date: null,
+      },
+      // Granted (lastAction: field_grant, allowed)
+      {
+        active: true,
+        description: null,
+        diagnosticCode: null,
+        lastAction: 'field_grant',
+        date: null,
+      },
+      {
+        active: true,
+        description: null,
+        diagnosticCode: null,
+        lastAction: 'allowed',
+        date: null,
+      },
+      // Remand (lastAction: remand, cavc_remand)
+      {
+        active: true,
+        description: null,
+        diagnosticCode: null,
+        lastAction: 'remand',
+        date: null,
+      },
+      // Denied (lastAction: denied)
+      {
+        active: true,
+        description: null,
+        diagnosticCode: null,
+        lastAction: 'denied',
+        date: null,
+      },
+      // Withdrawn (lastAction: withdrawn)
+      {
+        active: true,
+        description: null,
+        diagnosticCode: null,
+        lastAction: 'withdrawn',
+        date: null,
+      },
     ]
-    render(<AppealIssues issues={issues} {...mockNavProps()} />)
+    render(<AppealIssues appealType="appeal" issues={issues} {...mockNavProps()} />)
   })
 
   it('should initialize', () => {
@@ -87,5 +140,43 @@ context('AppealIssues', () => {
     // withdrawn
     expect(screen.getByRole('header', { name: t('appealDetails.withdrawnText') })).toBeTruthy()
     expect(screen.getByText('Eligibility for loan guaranty benefits withdrawn')).toBeTruthy()
+
+    // Test that the correct number of null description messages are rendered
+    // Under consideration: 2 null issues, Granted: 2 null issues = 2 total "2 issues" messages
+    // Remand: 2 null issues, Denied: 1 null issue, Withdrawn: 1 null issue = 3 total "1 issue" messages
+    expect(screen.getAllByText(t("We're unable to show 2 issues on appeal"))).toHaveLength(2)
+    expect(screen.getAllByText(t("We're unable to show 1 issue on appeal"))).toHaveLength(3)
+  })
+
+  it('should handle supplemental claim appeal type', () => {
+    const issues: AppealIssue[] = [
+      {
+        active: true,
+        description: null,
+        diagnosticCode: null,
+        lastAction: null,
+        date: null,
+      },
+    ]
+
+    render(<AppealIssues appealType="supplementalClaim" issues={issues} {...mockNavProps()} />)
+
+    expect(screen.getByText(t("We're unable to show 1 issue on your Supplemental Claim"))).toBeTruthy()
+  })
+
+  it('should handle higher level review appeal type', () => {
+    const issues: AppealIssue[] = [
+      {
+        active: true,
+        description: null,
+        diagnosticCode: null,
+        lastAction: null,
+        date: null,
+      },
+    ]
+
+    render(<AppealIssues appealType="higherLevelReview" issues={issues} {...mockNavProps()} />)
+
+    expect(screen.getByText(t("We're unable to show 1 issue on your Higher-Level Review"))).toBeTruthy()
   })
 })

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/AppealDetailsScreen/AppealIssues/AppealIssues.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/AppealDetailsScreen/AppealIssues/AppealIssues.tsx
@@ -1,19 +1,27 @@
 import React, { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { AppealIssue, AppealIssueLastAction } from 'api/types'
+import { AppealIssue, AppealIssueLastAction, AppealTypes } from 'api/types'
+import { AppealTypesDisplayNames } from 'api/types/ClaimsAndAppealsData'
 import { AccordionCollapsible, Box, BoxProps, TextArea, TextView, VABulletList } from 'components'
 import { NAMESPACE } from 'constants/namespaces'
 import { a11yLabelVA } from 'utils/a11yLabel'
 import { useTheme } from 'utils/hooks'
 
 type AppealIssuesProps = {
+  appealType: AppealTypes
   issues: Array<AppealIssue>
 }
 
-function AppealIssues({ issues }: AppealIssuesProps) {
+function AppealIssues({ appealType, issues }: AppealIssuesProps) {
   const { t } = useTranslation(NAMESPACE.COMMON)
   const theme = useTheme()
+
+  console.log('appealType', AppealTypesDisplayNames[appealType])
+
+  const appealTypeName = appealType.includes('appeal')
+    ? AppealTypesDisplayNames[appealType]
+    : `your ${AppealTypesDisplayNames[appealType]}`
 
   const issuesByStatus = useMemo(() => {
     const byStatus: {
@@ -71,7 +79,16 @@ function AppealIssues({ issues }: AppealIssuesProps) {
     if (!items.length) {
       return null
     }
-    const listOfIssues = items.map((item) => item.description)
+    const itemsWithNullDescription = items.filter((item) => item.description === null)
+    const itemsWithDescriptions = items.filter((item) => item.description !== null)
+    const listOfIssues = itemsWithDescriptions.map((item) => item.description as string)
+
+    // Add one item that informs the user of how many issues have null descriptions
+    // This will display one list item per status (remand, granted, etc.)
+    if (itemsWithNullDescription.length > 0) {
+      const issueText = itemsWithNullDescription.length > 1 ? 'issues' : 'issue'
+      listOfIssues.push(t(`We're unable to show ${itemsWithNullDescription.length} ${issueText} on ${appealTypeName}`))
+    }
     return (
       <>
         <TextView

--- a/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/AppealDetailsScreen/AppealIssues/AppealIssues.tsx
+++ b/VAMobile/src/screens/BenefitsScreen/ClaimsScreen/AppealDetailsScreen/AppealIssues/AppealIssues.tsx
@@ -19,7 +19,7 @@ function AppealIssues({ appealType, issues }: AppealIssuesProps) {
 
   console.log('appealType', AppealTypesDisplayNames[appealType])
 
-  const appealTypeName = appealType.includes('appeal')
+  const appealTypeName = appealType.toLowerCase().includes('appeal')
     ? AppealTypesDisplayNames[appealType]
     : `your ${AppealTypesDisplayNames[appealType]}`
 

--- a/VAMobile/src/store/api/demo/mocks/default/claims.json
+++ b/VAMobile/src/store/api/demo/mocks/default/claims.json
@@ -3955,6 +3955,62 @@
             "active": false,
             "lastAction": null,
             "date": "02-04-11"
+          },
+          {
+            "description": null,
+            "diagnosticCode": null,
+            "active": true,
+            "lastAction": "remand",
+            "date": null
+          },
+          {
+            "description": "Service connection, neck strain",
+            "diagnosticCode": "8518",
+            "active": true,
+            "lastAction": "remand",
+            "date": null
+          },
+          {
+            "description": null,
+            "diagnosticCode": null,
+            "active": false,
+            "lastAction": null,
+            "date": "02-04-11"
+          },
+          {
+            "description": null,
+            "diagnosticCode": null,
+            "active": true,
+            "lastAction": "denied",
+            "date": "03-04-11"
+          },
+          {
+            "description": null,
+            "diagnosticCode": null,
+            "active": true,
+            "lastAction": "field_grant",
+            "date": null
+          },
+          {
+            "description": null,
+            "diagnosticCode": null,
+            "active": false,
+            "lastAction": "remand",
+            "date": null
+          },
+          {
+            "description": null,
+            "diagnosticCode": null,
+            "active": true,
+            "lastAction": "field_grant",
+            "date": null
+          },
+          {
+            "description": null,
+            "diagnosticCode": null,
+            "active": true,
+            "lastAction": "withdrawn",
+            "date": null
           }
         ],
         "location": "bva",
@@ -5150,6 +5206,20 @@
             "active": true,
             "lastAction": null,
             "date": null
+          },
+          {
+            "description": null,
+            "diagnosticCode": null,
+            "active": true,
+            "lastAction": null,
+            "date": "02-04-11"
+          },
+          {
+            "description": null,
+            "diagnosticCode": null,
+            "active": true,
+            "lastAction": null,
+            "date": "2008-04-10"
           }
         ],
         "location": "bva",
@@ -5193,6 +5263,20 @@
             "diagnosticCode": "7518",
             "active": true,
             "lastAction": null,
+            "date": null
+          },
+          {
+            "description": null,
+            "diagnosticCode": null,
+            "active": true,
+            "lastAction": null,
+            "date": null
+          },
+          {
+            "description": null,
+            "diagnosticCode": null,
+            "active": false,
+            "lastAction": "denied",
             "date": null
           }
         ],


### PR DESCRIPTION
## Description of Change
<!-- Please include a description of the change and context. What would a code reviewer, or a future dev, 
need to know about this PR in order to understand why this PR was created? This could include dependencies 
introduced, changes in behavior, pointers to more detailed documentation. The description should be more 
than a link to an issue. -->
This code allows appeals with `null` issue descriptions to be accepted and displays a list item under the corresponding appeal status (remand, denied, under consideration, etc.) that informs the user of how many issues have null descriptions.

Prior to this change, if `null` issue descriptions were acceptable (they currently throw an error because the backend JSON schema does not allow for them), the app would break. 

## Important!!!
### None of the code changes in this PR will take effect until the backend JSON schema for appeal issues (https://github.com/department-of-veterans-affairs/vets-api/blob/master/lib/caseflow/schema/appeals_issue.json#L8) has been updated.

## Link to Issue
https://github.com/orgs/department-of-veterans-affairs/projects/1549/views/9?pane=issue&itemId=131653765&issue=department-of-veterans-affairs%7Cva.gov-team%7C121006

## Screenshots/Video
### Before
- The app would break as it's currently not possible for issue descriptions to be null
<img width="460" height="899" alt="Screenshot 2025-10-02 at 11 53 12 AM" src="https://github.com/user-attachments/assets/489f195b-ea83-4e72-96bb-33d6000fa2a9" />

### After
- *Scenario 1:* There are null issue descriptions for an appeal with the subtype of "legacyAppeal" or "appeal"
<img width="385" height="870" alt="Screenshot 2025-10-02 at 11 55 49 AM" src="https://github.com/user-attachments/assets/ceca02e3-42ec-4315-996d-6af446799c42" />

- *Scenario 2:* There are null issue descriptions for an appeal with the subtype of "higherLevelReview"
<img width="463" height="878" alt="Screenshot 2025-10-02 at 12 06 10 PM" src="https://github.com/user-attachments/assets/8d8e5694-3623-4249-bc90-eebec8514469" />

- *Scenario 3:* There are null issue descriptions for an appeal with the subtype of "supplementalClaim"
<img width="416" height="877" alt="Screenshot 2025-10-02 at 12 09 06 PM" src="https://github.com/user-attachments/assets/41aebc8b-dd7b-4a5e-82da-73e278a91fdb" />

## Testing Requirements
Local, unit and e2e testing was performed.

Acceptance Criteria
### Steps to reproduce:
1. Login as the demo user and on the home page click on the "Claims" tab.
2. Scroll down and click on the right arrow icon to go to the next page. The third and fourth items down from the top should be titled "Higher level review received appeal" and "Supplemental claim received appeal" respectively. Click on the Higher level review appeal.
- <img width="300" height="200" alt="Screenshot 2025-10-02 at 12 49 34 PM" src="https://github.com/user-attachments/assets/1042a638-55dc-4ffb-b24f-d5bfcbbeddac" />
4. Once on the show page of the appeal, click on the "Issues" tab. Within the "Currently on appeal" section and in the "Under consideration" section, it should have a list item that says "We're unable to show 1 issue on...."
- <img width="300" height="200" alt="Screenshot 2025-10-02 at 12 52 21 PM" src="https://github.com/user-attachments/assets/25d8f75d-d4f8-4e2f-a585-373d558e5448" />
5. Go back and click on the "Supplemental claim received appeal" from above and repeat step 4. However, this time, it should say "We're unable to show 2 issues on...."
6. Go back and navigate to the very last page in the list and click on the very last appeal
- <img width="300" height="200" alt="Screenshot 2025-10-02 at 12 56 04 PM" src="https://github.com/user-attachments/assets/9e09e826-fa86-4995-859d-e671bbea8809" />
7. Go to the "Issues" tab and ensure that every possible issue status (5 in total: "Under consideration", "remand", "granted", "denied", and "withdrawn") has a list item with the amount of null issue descriptions.
- <img width="300" height="200" alt="Screenshot 2025-10-02 at 12 56 50 PM" src="https://github.com/user-attachments/assets/ded191aa-b74c-44b8-b4c0-2b1d96ecaea1" />

- [ ] Each issue "status", if applicable, displays a list item for issues with null descriptions.
- [ ] The text differs depending on the appeal subtype ("appeal", "legacyAppeal", "higherLevelReview") and the amount of issues with null descriptions

Test User(s)
<!-- What test users should be used to test test this feature? Please specify what each test user should test. -->

- [ ] Demo user

## Checklist for PR Submitter
<!-- PR Submitter should make sure all of these items are checked off before requesting a review -->
  **PR Reviewer:** Confirm the items below as you review

### Administrative and documentation

- [X] PR is connected to issue(s)
- [X] Acceptance criteria is added on this PR or referenced from the attached issue

### Code testing

- [X] Unit tests have been created or updated to cover this change
- [X] End to end (Detox) tests have been created or updated to cover this change

### Code implementation

- [X] All imports are absolute (no relative imports)
- [X] No magic strings (All string unions follow the [Union -> Constant](https://github.com/department-of-veterans-affairs/va-mobile-app/blob/develop/VAMobile/src/constants/common.ts) type pattern)
- [X] No secrets or API keys are checked present in the code

### New features

- [X] No feature flag is needed because the code will not work until the backend has been updated
- [ ] Design and UX has been approved by the code mobile team (documented on the PR or attached issue)

## Checklist for QA
<!-- This checklist is for the QA to complete. -->
  **QA Engineer:** Check off the items below as you test

- [ ] Tested on iOS
- [ ] Tested on Android

[Run a build for this branch](https://github.com/department-of-veterans-affairs/va-mobile-app/actions/workflows/on_demand_build.yml)